### PR TITLE
 Move from using a ValueTuple of floats for a spectrum point to a named class, to aid readability

### DIFF
--- a/MzmlReader/BasePeak.cs
+++ b/MzmlReader/BasePeak.cs
@@ -6,6 +6,6 @@ namespace MzmlParser
     {
         public double Mz { get; set; }
         public double RetentionTime { get; set; }
-        public List<(float, float, float)> Spectrum { get; set; } //intensity, m/z, RT
+        public List<SpectrumPoint> Spectrum { get; set; }
     }
 }

--- a/MzmlReader/SpectrumPoint.cs
+++ b/MzmlReader/SpectrumPoint.cs
@@ -1,0 +1,25 @@
+﻿namespace MzmlParser
+{
+    /// <summary>
+    /// A point in the 2-dimensional LC-MS space of retention time and m/z, recording intensity.
+    /// </summary>
+    /// <remarks>
+    /// Arguably, this should be a struct, for ease of memory management and pointer dereferencing within the VM.
+    /// It's arguable because the class reduces copying overhead of arrays, so the optimisation depends on the exact use case.
+    /// </remarks>
+    public class SpectrumPoint
+    {
+        /// <remarks>Depending on the use of this class, this may be raw retention time or iRT. Within MzmlParser, it's raw and in TODO: seconds.</remarks>
+        public float RetentionTime { get; set; }
+        /// <summary>
+        /// Mass over charge, in Daltons.
+        /// </summary>
+        public float Mz { get; set; }
+        public float Intensity { get; set; }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(RetentionTime={RetentionTime}, Mz={Mz}, Intensity={Intensity})";
+        }
+    }
+}


### PR DESCRIPTION
I really should learn how to make distinct patches - sorry, this includes the previous PR as well.  The intent here is to avoid unnamed field access; I'm aware that I could have done this via named tuples, but the approach here also allows us to decide between struct and class later.