### PR TITLE
Undivided metrics added

### DIFF
--- a/MzmlReader/MzmlParser.cs
+++ b/MzmlReader/MzmlParser.cs
@@ -242,7 +242,7 @@ namespace MzmlParser
 
             //Want to potentially chuck 30GB of scan data into RAM? This is how you do it...
             //scan.Scan.Spectrum = spectrum;
-
+            scan.Scan.Density = spectrum.Count();
             scan.Scan.BasePeakIntensity = intensities.Max();
             scan.Scan.BasePeakMz = mzs[Array.IndexOf(intensities, (int)scan.Scan.BasePeakIntensity)];
             AddScanToRun(scan.Scan, run);

--- a/MzmlReader/Run.cs
+++ b/MzmlReader/Run.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 

--- a/MzmlReader/Scan.cs
+++ b/MzmlReader/Scan.cs
@@ -13,7 +13,7 @@ namespace MzmlParser
         public double IsolationWindowTargetMz { get; set; }
         public double IsolationWindowUpperOffset { get; set; }
         public double IsolationWindowLowerOffset { get; set; }
-
+        public int Density { get; set; }
         public List<SpectrumPoint> Spectrum { get; set; }
     }
 

--- a/SwaMe/DivideByRT.cs
+++ b/SwaMe/DivideByRT.cs
@@ -9,18 +9,18 @@ namespace SwaMe
     {
         public void DivideByRT(MzmlParser.Run run, int division)
         {
-            StreamWriter sw = new StreamWriter("PeakWidths.csv");
-            sw.Write("Filename , ");
-            StreamWriter sym = new StreamWriter("Symmetry.csv");
-            sym.Write("Filename, ");
+            StreamWriter sw = new StreamWriter("PeakWidths.tsv");
+            sw.Write("Filename \t ");
+            StreamWriter sym = new StreamWriter("Symmetry.tsv");
+            sym.Write("Filename\t ");
             for (int divider = 0; divider < division; divider++)
             {
                 sw.Write("RTsegment");
                 sw.Write(division);
-                sw.Write(" , ");
+                sw.Write(" \t ");
                 sym.Write("RTsegment");
                 sym.Write(division);
-                sym.Write(" , ");
+                sym.Write(" \t ");
             }
             sw.Write("\n");
             sw.Write(run.SourceFileName);
@@ -41,9 +41,10 @@ namespace SwaMe
                     }
                 }
                 double pwMean = PeakwidthsTemp.Average();
-                sym.Write(" , ");
-                sym.Write(pwMean.ToString());
-                sw.Write(" , ");
+                double psMean = PeaksymTemp.Average();
+                sym.Write(" \t ");
+                sym.Write(psMean.ToString());
+                sw.Write(" \t ");
                 sw.Write(pwMean.ToString());
             }
             sw.Close();

--- a/SwaMe/UndividedMetrix.cs
+++ b/SwaMe/UndividedMetrix.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+
+namespace SwaMe
+{
+    class UndividedMetrics
+    {
+        public void UndividedMetrix(MzmlParser.Run run, double RTDuration, double swathSizeDifference, int MS2Count, int NumOfSwaths, double cycleTimes50, double cycleTimesIQR,int MS2Density50,int MS2DensityIQR, int MS1Count )
+        {
+            StreamWriter um = new StreamWriter("undividedMetrics.tsv");
+            um.Write("Filename \t RTDuration \t swathSizeDifference \t  MS2Count \t swathsPerCycle \t CycleTimes50 \t CycleTimesIQR \t MS2Density50 \t MS2DensityIQR \t MS1Count");
+            um.Write("\n");
+            um.Write(run.SourceFileName);
+            um.Write("\t");
+            um.Write(RTDuration);
+            um.Write("\t");
+            um.Write(swathSizeDifference);
+            um.Write("\t");
+            um.Write(MS2Count);
+            um.Write("\t");
+            um.Write(NumOfSwaths);
+            um.Write("\t");
+            um.Write(cycleTimes50);
+            um.Write("\t");
+            um.Write(cycleTimesIQR);
+            um.Write("\t");
+            um.Write(MS2Density50);
+            um.Write("\t");
+            um.Write(MS2DensityIQR);
+            um.Write("\t");
+            um.Write(MS1Count);
+            um.Close();
+        }
+    }
+}


### PR DESCRIPTION
The metrics that are not divided by RT or swath but instead simply give one result per file are added. Format of files that are output is changed to tsv.