### PR TITLE
Fixed three errors - filetype, cycletime calcError and segmentDivision

### DIFF
--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -121,7 +121,7 @@ namespace MzmlParser
             //This has only been tested on Sciex converted data
             //
             //Paul Brack 2019/04/03
-            if (run.SourceFileType.ToUpper().EndsWith("WIFF") || run.SourceFileName.ToUpper().EndsWith("SCAN"))
+            if (run.SourceFileType.ToUpper().EndsWith("WIFF") || run.SourceFileType.ToUpper().EndsWith("SCAN"))
             {
                 scan.Scan.Cycle = int.Parse(reader.GetAttribute("id").Split(' ').Single(x => x.Contains("cycle")).Split('=').Last());
             }

--- a/SwaMe/FileMaker.cs
+++ b/SwaMe/FileMaker.cs
@@ -73,7 +73,7 @@ namespace SwaMe
         {
             string metricsPerRTSegmentFile = "RTDividedMetrics_"+ run.SourceFileName+ ".tsv";
             StreamWriter streamWriter = new StreamWriter(metricsPerRTSegmentFile);
-            streamWriter.Write("Filename\t RTsegment \t MS2Peakwidths \t PeakSymmetry \t MS2PeakCapacity \t MS2Peakprecision \t MS1PeakPrecision \t DeltaTICAverage \t DeltaTICIQR \t AveScanTime \t AveMS2Density \t AveMS1Density \t MS2TICTotal \t MS1TICTotal");
+            streamWriter.Write("Filename\t RTsegment \t MS2Peakwidths \t PeakSymmetry \t MS2PeakCapacity \t MS2Peakprecision \t MS1PeakPrecision \t DeltaTICAverage \t DeltaTICIQR \t AveCycleTime \t AveMS2Density \t AveMS1Density \t MS2TICTotal \t MS1TICTotal");
 
             for (int segment = 0; segment < division; segment++)
             {

--- a/SwaMe/RTGrouper.cs
+++ b/SwaMe/RTGrouper.cs
@@ -56,10 +56,10 @@ namespace SwaMe
                 //Check to see in which RTsegment this basepeak is:
                 for (int segmentboundary = 1; segmentboundary < RTsegs.Count(); segmentboundary++)
                 {
-                    if (basepeak.RetentionTime < RTsegs[0]) basepeak.RTsegment = 0;
+                    if (basepeak.RetentionTime > RTsegs.Last()) basepeak.RTsegment = RTsegs.Count()-1;
                     if (basepeak.RetentionTime > RTsegs[segmentboundary - 1] && basepeak.RetentionTime < RTsegs[segmentboundary])
                     {
-                        basepeak.RTsegment = segmentboundary;
+                        basepeak.RTsegment = segmentboundary-1;
                     }
                 }
             }
@@ -70,10 +70,10 @@ namespace SwaMe
                 //if the scan starttime falls into the rtsegment, give it the correct rtsegment number
                 for (int segmentboundary = 1; segmentboundary < RTsegs.Count(); segmentboundary++)
                 {
-                    if (scan.ScanStartTime < RTsegs[0]) { scan.RTsegment = 0; break; }
+                    if (scan.ScanStartTime > RTsegs.Last()) scan.RTsegment = RTsegs.Count()-1;
                     else if (scan.ScanStartTime > RTsegs[segmentboundary - 1] && scan.ScanStartTime < RTsegs[segmentboundary])
                     {
-                        scan.RTsegment = segmentboundary;
+                        scan.RTsegment = segmentboundary-1;
                         break;
                     }
                     else if (scan.ScanStartTime > RTsegs[segmentboundary] && segmentboundary == RTsegs.Count()) { scan.RTsegment = segmentboundary + 1; break; }
@@ -86,11 +86,14 @@ namespace SwaMe
                 //Check to see in which RTsegment this basepeak is:
                 for (int segmentboundary = 1; segmentboundary < RTsegs.Count(); segmentboundary++)
                 {
-                    if (scan.ScanStartTime < RTsegs[0]) scan.RTsegment = 0;
-                    if (scan.ScanStartTime > RTsegs[segmentboundary - 1] && scan.ScanStartTime < RTsegs[segmentboundary])
+                    if (scan.ScanStartTime > RTsegs.Last()) scan.RTsegment = RTsegs.Count()-1;
+                    else if (scan.ScanStartTime > RTsegs[segmentboundary - 1] && scan.ScanStartTime < RTsegs[segmentboundary])
                     {
-                        scan.RTsegment = segmentboundary;
+                        scan.RTsegment = segmentboundary - 1;
+                        break;
                     }
+                    else if (scan.ScanStartTime > RTsegs[segmentboundary] && segmentboundary == RTsegs.Count()) { scan.RTsegment = segmentboundary + 1; break; }
+
                 }
             }
 
@@ -185,7 +188,7 @@ namespace SwaMe
                     }
                 }
 
-                cycleTime.Add((lastCycle - firstCycle) / (lastScanStartTime - firstScanStartTime));
+                cycleTime.Add((lastScanStartTime - firstScanStartTime)/(lastCycle - firstCycle));
                 if (PeakwidthsTemp.Count > 0)
                 {
                     Peakwidths.Add(PeakwidthsTemp.Average());


### PR DESCRIPTION
1 - Type was still being allocated via sourcefilename instead of sourcefiletype at one spot.

2-The metric AveScanTime should firstly be called AveCycleTime and secondly it calculated the number of cycles per segment/ time taken for each segment instead of the other way around.

3- The segments were being allocated to one segment higher than its actual segment number! Segment 10 was being allocated to segment 0.