### PR TITLE
BasePeaksNotWithinRTtoleranceAdded

### DIFF
--- a/MzmlReader/BasePeak.cs
+++ b/MzmlReader/BasePeak.cs
@@ -1,16 +1,44 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MzmlParser
 {
     public class BasePeak
     {
         public double Mz { get; set; }
-        public double Intensity { get; set; }
-        public double RetentionTime { get; set; }
+        public List<double> Intensities { get; set; }
         public List<SpectrumPoint> Spectrum { get; set; }
-        public double RTsegment { get; set; }
-        public double FWHM;
-        public double Peaksym;
-        public double PeakCapacity;
+        public List<double> RTsegments { get; set; }
+        public List<double> FWHMs;
+        public List<double> Peaksyms;
+        public List<double> PeakCapacities;
+        public List<double> bpkRTs;
+
+        public BasePeak (Scan scan, double massTolerance, List<SpectrumPoint>spectrum)
+        {
+            Mz = scan.BasePeakMz;
+            Intensities = new List<double>();
+            Intensities.Add(scan.BasePeakIntensity);
+            Spectrum = spectrum.Where(x => Math.Abs(x.Mz - scan.BasePeakMz) <= massTolerance).OrderByDescending(x => x.Intensity).Take(1).ToList();
+            bpkRTs = new List<double>();
+            bpkRTs.Add(scan.ScanStartTime);
+            RTsegments = new List<double>();
+            FWHMs = new List<double>();
+            Peaksyms = new List<double>();
+            PeakCapacities = new List<double>();
+        }
+        public BasePeak(double mz)
+        {
+            Mz = mz;
+            Intensities = new List<double>();
+            Spectrum = new List<SpectrumPoint>();
+            bpkRTs = new List<double>();
+            RTsegments = new List<double>();
+            FWHMs = new List<double>();
+            Peaksyms = new List<double>();
+            PeakCapacities = new List<double>();
+        }
+
     }
 }

--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -329,9 +329,23 @@ namespace MzmlParser
                     //Check to see if we have a basepeak we can add points to
                     else
                     {
+                        bool withinRTtolerance = false;
                         foreach (BasePeak bp in run.BasePeaks.Where(x => Math.Abs(x.RetentionTime - scan.Scan.ScanStartTime) <= rtTolerance && Math.Abs(x.Mz - scan.Scan.BasePeakMz) <= massTolerance))
                         {
                             bp.Spectrum.Add(spectrum.Where(x => Math.Abs(x.Mz - bp.Mz) <= massTolerance).OrderByDescending(x => x.Intensity).First());
+                            withinRTtolerance = true;
+                        }
+                       if (withinRTtolerance == false)
+                        {
+                            spectrum.Select(x => Math.Abs(x.Mz - scan.Scan.BasePeakMz) <= massTolerance);
+                            BasePeak basePeak = new BasePeak()
+                            {
+                                Mz = scan.Scan.BasePeakMz,
+                                RetentionTime = scan.Scan.ScanStartTime,
+                                Intensity = scan.Scan.BasePeakIntensity,
+                                Spectrum = spectrum.Where(x => Math.Abs(x.Mz - scan.Scan.BasePeakMz) <= massTolerance).OrderByDescending(x => x.Intensity).Take(1).ToList()
+                            };
+                            run.BasePeaks.Add(basePeak);
                         }
                     }
                 }

--- a/SwaMe/ChromatogramMetricGenerator.cs
+++ b/SwaMe/ChromatogramMetricGenerator.cs
@@ -17,45 +17,49 @@ namespace SwaMe
             //Crawdad
             foreach (BasePeak basepeak in run.BasePeaks)
             {
-                double[] intensities = basepeak.Spectrum.Select(x => (double)x.Intensity).ToArray();
-                double[] starttimes = basepeak.Spectrum.Select(x => (double)x.RetentionTime).ToArray();
-                if (intensities.Count() > 1)
+                //for each peak within the spectrum 
+                for (int yyy = 0; yyy < basepeak.bpkRTs.Count(); yyy++)
                 {
-                    RTandInt inter = new RTandInt();
-                    inter = Interpolate(starttimes, intensities);
-                    starttimes = inter.starttimes;
-                    intensities = inter.intensities;
-                }
-                CrawdadSharp.CrawdadPeakFinder cPF = new CrawdadSharp.CrawdadPeakFinder();
-                cPF.SetChromatogram(intensities,starttimes);
-                List<CrawdadSharp.CrawdadPeak> crawPeaks = cPF.CalcPeaks();
-                double TotalFWHM = 0;
-                double TotalFWPCNT = 0;
-                double TotalPC = 0;
-                foreach (CrawdadSharp.CrawdadPeak crawPeak in crawPeaks)
-                {
-                    double peakTime = starttimes[crawPeak.TimeIndex];
-                    double fwhm = crawPeak.Fwhm;
-                    if (fwhm == 0 )
+                    double[] intensities = basepeak.Spectrum.Select(x => (double)x.Intensity).ToArray();
+                    double[] starttimes = basepeak.Spectrum.Select(x => (double)x.RetentionTime).ToArray();
+                    if (intensities.Count() > 1)
                     {
-                        logger.Info( "FWHM is zero. ");
-                        continue;
+                        RTandInt inter = new RTandInt();
+                        inter = Interpolate(starttimes, intensities);
+                        starttimes = inter.starttimes;
+                        intensities = inter.intensities;
                     }
-                    TotalFWPCNT += crawPeak.Fwfpct;
-                    TotalFWHM += fwhm;
-                    TotalPC += 1 + (peakTime / fwhm);
-                }
-                if (crawPeaks.Count() > 0)
-                {
-                    basepeak.FWHM = TotalFWHM / crawPeaks.Count();
-                    basepeak.Peaksym = TotalFWPCNT / crawPeaks.Count();
-                    basepeak.PeakCapacity = TotalPC / crawPeaks.Count();
-                }
-                else
-                {
-                    basepeak.FWHM = 0;
-                    basepeak.PeakCapacity = 0;
-                    basepeak.Peaksym = 0;
+                    CrawdadSharp.CrawdadPeakFinder cPF = new CrawdadSharp.CrawdadPeakFinder();
+                    cPF.SetChromatogram(intensities, starttimes);
+                    List<CrawdadSharp.CrawdadPeak> crawPeaks = cPF.CalcPeaks();
+                    double TotalFWHM = 0;
+                    double TotalFWPCNT = 0;
+                    double TotalPC = 0;
+                    foreach (CrawdadSharp.CrawdadPeak crawPeak in crawPeaks)
+                    {
+                        double peakTime = starttimes[crawPeak.TimeIndex];
+                        double fwhm = crawPeak.Fwhm;
+                        if (fwhm == 0)
+                        {
+                            logger.Info("FWHM is zero. ");
+                            continue;
+                        }
+                        TotalFWPCNT += crawPeak.Fwfpct;
+                        TotalFWHM += fwhm;
+                        TotalPC += 1 + (peakTime / fwhm);
+                    }
+                    if (crawPeaks.Count() > 0)
+                    {
+                        basepeak.FWHMs.Add(TotalFWHM / crawPeaks.Count());
+                        basepeak.Peaksyms.Add(TotalFWPCNT / crawPeaks.Count());
+                        basepeak.PeakCapacities.Add(TotalPC / crawPeaks.Count());
+                    }
+                    else
+                    {
+                        basepeak.FWHMs.Add(0);
+                        basepeak.PeakCapacities.Add(0);
+                        basepeak.Peaksyms.Add(0);
+                    }
                 }
 
 

--- a/SwaMe/MetricGenerator.cs
+++ b/SwaMe/MetricGenerator.cs
@@ -9,8 +9,8 @@ namespace SwaMe
         public void GenerateMetrics(Run run, int division,  string inputFilePath, double massTolerance, bool irt)
         {
            
-            //Acquire RTDuration:
-            double RTDuration = run.BasePeaks[run.BasePeaks.Count() - 1].RetentionTime - run.BasePeaks[0].RetentionTime;
+            //Acquire RTDuration: last minus first
+            double RTDuration = run.BasePeaks.Last().bpkRTs.Last() - run.BasePeaks.First().bpkRTs.First();
 
             //Interpolate, Smooth, create chromatogram and generate chromatogram metrics
             ChromatogramMetricGenerator chromatogramMetrics = new ChromatogramMetricGenerator();

--- a/Yamato.sln
+++ b/Yamato.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28922.388


### PR DESCRIPTION
Previously basepeaks that occur later in the run were not added as their basepeak had already occurred and a new basepeak with the same m/z was not created again. However, this means we lose all the other peaks for the basepeak. We now add those basepeaks as well.