### PR TITLE
Extra run through parser to collect basepeaks added

### DIFF
--- a/Console/Program.cs
+++ b/Console/Program.cs
@@ -83,10 +83,6 @@ namespace Yamato.Console
                     logger.Info("Parsed file in {0} seconds", Convert.ToInt32(sw.Elapsed.TotalSeconds));
                     logger.Info("Done!");
 
-                    run = new MzmlParser.ChromatogramGenerator().CreateAllChromatograms(run);
-                    new SwaMe.MetricGenerator().GenerateMetrics(run, division, inputFilePath, massTolerance, irt);
-                    logger.Info("Parsed file in {0} seconds", Convert.ToInt32(sw.Elapsed.TotalSeconds));
-                    logger.Info("Done!");
                 }
             });
             LogManager.Shutdown();

--- a/MzmlReader/BasePeak.cs
+++ b/MzmlReader/BasePeak.cs
@@ -13,7 +13,7 @@ namespace MzmlParser
         public List<double> FWHMs;
         public List<double> Peaksyms;
         public List<double> PeakCapacities;
-        public List<double> bpkRTs;
+        public List<double> BpkRTs;
 
         public BasePeak (Scan scan, double massTolerance, List<SpectrumPoint>spectrum)
         {
@@ -21,19 +21,21 @@ namespace MzmlParser
             Intensities = new List<double>();
             Intensities.Add(scan.BasePeakIntensity);
             Spectrum = spectrum.Where(x => Math.Abs(x.Mz - scan.BasePeakMz) <= massTolerance).OrderByDescending(x => x.Intensity).Take(1).ToList();
-            bpkRTs = new List<double>();
-            bpkRTs.Add(scan.ScanStartTime);
+            BpkRTs = new List<double>();
+            BpkRTs.Add(scan.ScanStartTime);
             RTsegments = new List<double>();
             FWHMs = new List<double>();
             Peaksyms = new List<double>();
             PeakCapacities = new List<double>();
         }
-        public BasePeak(double mz)
+        public BasePeak(double mz, double scanStartTime, double basepeakintensity)
         {
             Mz = mz;
             Intensities = new List<double>();
+            Intensities.Add(basepeakintensity);
             Spectrum = new List<SpectrumPoint>();
-            bpkRTs = new List<double>();
+            BpkRTs = new List<double>();
+            BpkRTs.Add(scanStartTime);
             RTsegments = new List<double>();
             FWHMs = new List<double>();
             Peaksyms = new List<double>();

--- a/MzmlReader/QuickScan.cs
+++ b/MzmlReader/QuickScan.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MzmlParser
+{
+    public class QuickScan
+    {
+        public int mslevel { get; set; }
+        public double scanStartTime { get; set; }
+        public string base64IntensityArray { get; set; }
+        public int intensityBitLength { get; set; }
+        public bool intensityZlibCompressed { get; set; }
+        public string base64MzArray { get; set; }
+        public int mzBitLength { get; set; }
+        public bool mzZlibCompressed { get; set; }
+    }
+}
+

--- a/SwaMe/ChromatogramMetricGenerator.cs
+++ b/SwaMe/ChromatogramMetricGenerator.cs
@@ -18,7 +18,7 @@ namespace SwaMe
             foreach (BasePeak basepeak in run.BasePeaks)
             {
                 //for each peak within the spectrum 
-                for (int yyy = 0; yyy < basepeak.bpkRTs.Count(); yyy++)
+                for (int yyy = 0; yyy < basepeak.BpkRTs.Count(); yyy++)
                 {
                     double[] intensities = basepeak.Spectrum.Select(x => (double)x.Intensity).ToArray();
                     double[] starttimes = basepeak.Spectrum.Select(x => (double)x.RetentionTime).ToArray();

--- a/SwaMe/MetricGenerator.cs
+++ b/SwaMe/MetricGenerator.cs
@@ -10,7 +10,7 @@ namespace SwaMe
         {
            
             //Acquire RTDuration: last minus first
-            double RTDuration = run.BasePeaks.Last().bpkRTs.Last() - run.BasePeaks.First().bpkRTs.First();
+            double RTDuration = run.BasePeaks.Last().BpkRTs.Last() - run.BasePeaks.First().BpkRTs.First();
 
             //Interpolate, Smooth, create chromatogram and generate chromatogram metrics
             ChromatogramMetricGenerator chromatogramMetrics = new ChromatogramMetricGenerator();

--- a/SwaMe/RTGrouper.cs
+++ b/SwaMe/RTGrouper.cs
@@ -47,29 +47,34 @@ namespace SwaMe
 
             for (int i = 0; i < division; i++)
             {
-                RTsegs[i] = run.BasePeaks[0].bpkRTs[0] + RTsegment * i;
+                RTsegs[i] = run.BasePeaks[0].BpkRTs[0] + RTsegment * i;
             }
 
             //dividing basepeaks into segments
             foreach (MzmlParser.BasePeak basepeak in run.BasePeaks)
             {
                 //Check to see in which RTsegment this basepeak is:
-                for (int iii = 0; iii < basepeak.bpkRTs.Count()-1; iii++)
+                foreach (double rt in basepeak.BpkRTs)
                 {
-                    for (int segmentboundary = 1; segmentboundary < RTsegs.Count(); segmentboundary++)
+                    if (rt > RTsegs.Last())
                     {
-                        if (basepeak.bpkRTs[iii] > RTsegs.Last())
-                        {
-                            basepeak.RTsegments.Add(RTsegs.Count() - 1);
-                            break;
-                        }
-                        else if (basepeak.bpkRTs[iii] > RTsegs[segmentboundary - 1] && basepeak.bpkRTs[iii] < RTsegs[segmentboundary])
+                        basepeak.RTsegments.Add(RTsegs.Count() - 1);
+                    }
+                    else if (RTsegs.Count()>1 && rt < RTsegs[1])
+                    {
+                        basepeak.RTsegments.Add(RTsegs.First());
+                    }
+                    else for (int segmentboundary= 2; segmentboundary < RTsegs.Count();segmentboundary++)
+                    {
+                        if (rt > RTsegs[segmentboundary - 1] && rt < RTsegs[segmentboundary])
                         {
                             basepeak.RTsegments.Add(segmentboundary - 1);
-                            break;
+                            segmentboundary = RTsegs.Count();//move to the next bpkRT
                         }
+                        
                     }
                 }
+               
             }
 
             //dividing ms2scans into segments of RT


### PR DESCRIPTION
MzmlReader now loops through the file twice. First to gather info for the basepeaks then to add all the remaining information. With the knowledge of which basepeaks are present, proper chromatogram data can be added.
Also irt bool was added to allow the running of Yamato without irt if necessary.

Still needed from my side:
Chromatogram metrics are not yet calculating correctly. 
There is also part of the program at the end that appears to be running twice. More investigation is needed.