### PR TITLE
Small changes to make chromatogrammetrics work

### DIFF
--- a/Console/Yamato.Console.csproj
+++ b/Console/Yamato.Console.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="CenterSpace.NMath.Standard.Windows.X64" Version="7.0.0.47" />
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
 

--- a/MzmlReader/Run.cs
+++ b/MzmlReader/Run.cs
@@ -29,6 +29,7 @@ namespace MzmlParser
         public LibraryParser.Library IrtLibrary { get; set; }
         public List<IRTPeak> IRTPeaks { get; set; }
         public List<CandidateHit> IRTHits { get; set; }
+        public AnalysisSettings AnalysisSettings { get; set; }
     }
 
     public class Chromatograms
@@ -37,5 +38,10 @@ namespace MzmlParser
         public List<(double, double)> Ms2Tic { get; set; }
         public List<(double, double)> Ms1Bpc { get; set; }
         public List<(double, double)> Ms2Bpc { get; set; }
+    }
+    public class AnalysisSettings
+    {
+        public double MassTolerance { get; set; }
+        public double RtTolerance { get; set; }
     }
 }

--- a/SwaMe/ChromatogramMetricGenerator.cs
+++ b/SwaMe/ChromatogramMetricGenerator.cs
@@ -20,8 +20,9 @@ namespace SwaMe
                 //for each peak within the spectrum 
                 for (int yyy = 0; yyy < basepeak.BpkRTs.Count(); yyy++)
                 {
-                    double[] intensities = basepeak.Spectrum.Select(x => (double)x.Intensity).ToArray();
-                    double[] starttimes = basepeak.Spectrum.Select(x => (double)x.RetentionTime).ToArray();
+                    //change these two arrays to be only the spectra surrounding that bpkrt:
+                    double[] intensities = basepeak.Spectrum.Where(x=>Math.Abs(x.RetentionTime-basepeak.BpkRTs[yyy])<run.AnalysisSettings.RtTolerance).Select(x => (double)x.Intensity).ToArray();
+                    double[] starttimes = basepeak.Spectrum.Where(x => Math.Abs(x.RetentionTime - basepeak.BpkRTs[yyy]) < run.AnalysisSettings.RtTolerance).Select(x => (double)x.RetentionTime).ToArray();
                     if (intensities.Count() > 1)
                     {
                         RTandInt inter = new RTandInt();
@@ -66,7 +67,7 @@ namespace SwaMe
             }
         }
 
-        public void GenerateiRTChromatogram(Run run, double massTolerance)
+        public void GenerateiRTChromatogram(Run run)
         {
             int Count = 0;
             foreach (IRTPeak irtpeak in run.IRTPeaks)

--- a/SwaMe/MetricGenerator.cs
+++ b/SwaMe/MetricGenerator.cs
@@ -17,7 +17,7 @@ namespace SwaMe
             chromatogramMetrics.GenerateChromatogram(run);
 
             if (irt)
-                chromatogramMetrics.GenerateiRTChromatogram(run, massTolerance);
+                chromatogramMetrics.GenerateiRTChromatogram(run);
 
             //Calculating the largestswath
             double swathSizeDifference = CalcSwathSizeDiff(run);

--- a/SwaMe/RTGrouper.cs
+++ b/SwaMe/RTGrouper.cs
@@ -62,7 +62,7 @@ namespace SwaMe
                     }
                     else if (RTsegs.Count()>1 && rt < RTsegs[1])
                     {
-                        basepeak.RTsegments.Add(RTsegs.First());
+                        basepeak.RTsegments.Add(0);
                     }
                     else for (int segmentboundary= 2; segmentboundary < RTsegs.Count();segmentboundary++)
                     {


### PR DESCRIPTION
CrawDad now takes as input only the parts of the code  that are relevant to each instance of the basepeak.bpRT, not every time the basepeak is picked up. So instead of having one large chromatogram for the entire RT, we have smaller chromatograms related to each time said basepeak was picked up as a basepeak of a scan.

New class written within Run - analysissettings that contains masstolerance and rtTolerance.

Also protected against instances where the scan is empty in the basepeakparser.