### PR TITLE
FixedBugPreventingMultipleInputFiles

### DIFF
--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -53,6 +53,7 @@ namespace MzmlParser
 
             cde.Signal();
             cde.Wait();
+            cde.Reset(1);
             IrtPeptideMatcher.ChooseIrtPeptides(run);
 
             return run;


### PR DESCRIPTION
Another countdown event had been added, which needed resetting so it could increment when the next one of multiple files was run.