### PR TITLE
Allow files without an MS1 scan

### DIFF
--- a/SwaMe/FileMaker.cs
+++ b/SwaMe/FileMaker.cs
@@ -104,9 +104,9 @@ namespace SwaMe
                 streamWriter.Write(" \t ");
                 streamWriter.Write(rtMetrics.MS1Density.ElementAt(segment));
                 streamWriter.Write(" \t ");
-                streamWriter.Write(rtMetrics.MS1TicTotal.ElementAt(segment));
-                streamWriter.Write(" \t ");
                 streamWriter.Write(rtMetrics.MS2TicTotal.ElementAt(segment));
+                streamWriter.Write(" \t ");
+                streamWriter.Write(rtMetrics.MS1TicTotal.ElementAt(segment));
                 streamWriter.Write(" \t ");
             }
             streamWriter.Close();

--- a/SwaMe/MetricGenerator.cs
+++ b/SwaMe/MetricGenerator.cs
@@ -49,7 +49,10 @@ namespace SwaMe
 
         private double CalcSwathSizeDiff(Run run)
         {
-            return run.Ms2Scans.Select(s => s.IsolationWindowUpperOffset + s.IsolationWindowLowerOffset).OrderBy(x => x).Last();
+            run.Ms2Scans.Select(s => s.IsolationWindowUpperOffset + s.IsolationWindowLowerOffset).OrderBy(x => x);
+            double max = run.Ms2Scans.Select(s => s.IsolationWindowUpperOffset + s.IsolationWindowLowerOffset).Last();
+            double min = run.Ms2Scans.Select(s => s.IsolationWindowUpperOffset + s.IsolationWindowLowerOffset).First();
+            return max - min;
         }
 
         private List<double> CalcCycleTime(Run run)

--- a/SwaMe/RTGrouper.cs
+++ b/SwaMe/RTGrouper.cs
@@ -146,8 +146,9 @@ namespace SwaMe
             var meanMzOfAllBpks = run.BasePeaks.Select(x => x.Mz).Average();
 
             //Calculations for peakprecision MS1:
-            var mIMS1Bpks = run.Ms1Scans.Select(x => x.BasePeakIntensity).Average();
-            var mMMS1Bpks = run.Ms1Scans.Select(x => x.BasePeakMz).Average();
+            //double mIMS1Bpks;
+            //if (run.Ms1Scans.Count()>0) mIMS1Bpks = run.Ms1Scans.Select(x => x.BasePeakIntensity).Average();
+            //var mMMS1Bpks = run.Ms1Scans.Select(x => x.BasePeakMz).Average();
             List<double> peakWidths = new List<double>();
             List<double> peakSymmetry = new List<double>();
             List<double> peakCapacity = new List<double>();
@@ -206,6 +207,14 @@ namespace SwaMe
                 double ms2TicTotalTemp = 0;
                 foreach (MzmlParser.Scan scan in run.Ms2Scans)
                 {
+                    if (run.Ms1Scans.Count() < 1)
+                    {
+                        firstScanStartTime = Math.Min(firstScanStartTime, scan.ScanStartTime);
+                        lastScanStartTime = Math.Max(lastScanStartTime, scan.ScanStartTime);
+                        firstCycle = Math.Min(scan.Cycle, firstCycle);
+                        lastCycle = Math.Max(scan.Cycle, lastCycle);
+                    }
+
                     if (scan.RTsegment == segment)
                     {
                         firstCycle = Math.Min(scan.Cycle, firstCycle);


### PR DESCRIPTION
These changes allow the incorporation of files without an MS1scan.

Also the metric name and output were not correlated between MSTICTotal in Filemaker, which was rectified.