### PR TITLE
CombineFilesAtTheEnd

### DIFF
--- a/Console/Program.cs
+++ b/Console/Program.cs
@@ -12,8 +12,6 @@ using System.Collections.Concurrent;
 
 namespace Yamato.Console
 {
-
-
     class Program
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
@@ -24,7 +22,7 @@ namespace Yamato.Console
             Parser.Default.ParseArguments<Options>(args).WithParsed(options =>
             {
                 UpdateLoggingLevels(options);
-
+                bool combine = options.Combine;
                 List<string> inputFiles = new List<string>();
 
                 if (options.LoadFromDirectory != null && options.LoadFromDirectory == true)//multiple files
@@ -46,6 +44,8 @@ namespace Yamato.Console
 
                 foreach (string inputFilePath in inputFiles)
                 {
+                    bool lastFile = false;//saving whether its the last file or not, so if we need to combine all the files in the end, we know when the end is.
+                    if (inputFilePath == inputFiles.Last()) lastFile = true;
                     logger.Info("Loading file: {0}", inputFilePath);
                     Stopwatch sw = new Stopwatch();
                     sw.Start();
@@ -86,7 +86,7 @@ namespace Yamato.Console
                     MzmlParser.Run run = mzmlParser.LoadMzml(inputFilePath, irt, analysisSettings);
 
                     run = new MzmlParser.ChromatogramGenerator().CreateAllChromatograms(run);
-                    new SwaMe.MetricGenerator().GenerateMetrics(run, division, inputFilePath, irt);
+                    new SwaMe.MetricGenerator().GenerateMetrics(run, division, inputFilePath, irt, combine, lastFile);
                     logger.Info("Parsed file in {0} seconds", Convert.ToInt32(sw.Elapsed.TotalSeconds));
                     logger.Info("Done!");
 
@@ -154,6 +154,9 @@ namespace Yamato.Console
 
         [Option("rttolerance", Required = false, HelpText = "RT tolerance")]
         public double RtTolerance { get; set; } = 2.5;
+
+        [Option('c', "combineFiles" ,Required = false, HelpText = "Combine files at the end?")]
+        public bool Combine { get; set; } = true;
     }
 }
 

--- a/SwaMe/FileMaker.cs
+++ b/SwaMe/FileMaker.cs
@@ -233,9 +233,25 @@ namespace SwaMe
             string mzQCFile = @"metrics_" + run.SourceFileName+ ".json";
             new MzqcGenerator.MzqcWriter().WriteMzqc(mzQCFile, metrics);
 
-          
+        }
 
-            
+        public void CombineMultipleFilesIntoSingleFile(string inputFileNamePattern, string outputFileName)
+        {
+            string[] inputFiles = Directory.GetFiles(Directory.GetCurrentDirectory(), inputFileNamePattern);
+
+            StreamWriter combinedwriter = new StreamWriter(outputFileName);
+            int counter = 0;
+            foreach (var inputFile in inputFiles)
+            {
+                 var inputStream = File.ReadAllLines(inputFile);
+                 if (counter != 0) inputStream = inputStream.Skip(1).ToArray();
+                 foreach (string line in inputStream)
+                 {
+                     combinedwriter.WriteLine(line);
+                 }
+                 counter++;
+            }
+            combinedwriter.Close();
         }
     }
 }

--- a/SwaMe/MetricGenerator.cs
+++ b/SwaMe/MetricGenerator.cs
@@ -6,7 +6,7 @@ namespace SwaMe
 {
     public class MetricGenerator
     {
-        public void GenerateMetrics(Run run, int division,  string inputFilePath, bool irt)
+        public void GenerateMetrics(Run run, int division,  string inputFilePath, bool irt, bool combine, bool lastFile)
         {
 
             //Acquire RTDuration: last minus first
@@ -45,6 +45,13 @@ namespace SwaMe
             fileMaker.MakeMetricsPerRTsegmentFile(rtMetrics);
             fileMaker.MakeMetricsPerSwathFile(swathMetrics, inputFilePath);
             fileMaker.CreateAndSaveMzqc();
+            if (combine && lastFile)
+            {
+                fileMaker.CombineMultipleFilesIntoSingleFile("iRTMetrics_*", "AllIRTMetrics.tsv");
+                fileMaker.CombineMultipleFilesIntoSingleFile("MetricsBySwath_*", "AllMetricsBySwath.tsv");
+                fileMaker.CombineMultipleFilesIntoSingleFile("RTDividedMetrics_*", "AllRTDividedMetrics.tsv");
+                fileMaker.CombineMultipleFilesIntoSingleFile("undividedMetrics_*", "AllUndividedMetrics.tsv");
+             }
         }
 
        private List<double> CalcCycleTime(Run run)


### PR DESCRIPTION
When the last file is finished, SwaMe now combines all the tsv's of the same group it has output into one combined file. E.g. if two inputfiles a and b were run, there would be iRTMetrics_a.tsv and iRTMetrics_b.tsv in the same folder. Now there will also be a file AllIRTMetrics.tsv which is a combination of the two.