### PR TITLE
PredictedChargeStateOneProportionAdded

### DIFF
--- a/MzmlReader/Scan.cs
+++ b/MzmlReader/Scan.cs
@@ -18,6 +18,7 @@ namespace MzmlParser
         public int RTsegment { get; set; }
         public int Density { get; set; }
         public List<SpectrumPoint> Spectrum { get; set; }
+        public double proportionChargeStateOne { get; set; }
     }
 
     public class ScanAndTempProperties

--- a/SwaMe/FileMaker.cs
+++ b/SwaMe/FileMaker.cs
@@ -48,7 +48,7 @@ namespace SwaMe
         {
             //tsv
             StreamWriter streamWriter = new StreamWriter(dateTime +"_MetricsBySwath_" + run.SourceFileName + ".tsv");
-            streamWriter.Write("Filename \t swathNumber \t scansPerSwath \t AvgMzRange \t SwathProportionOfTotalTIC \t swDensityAverage \t swDensityIQR  \n");
+            streamWriter.Write("Filename \t swathNumber \t scansPerSwath \t AvgMzRange \t SwathProportionOfTotalTIC \t swDensityAverage \t swDensityIQR \t swAvgProportionSinglyCharged \n");
 
             for (int i = 0; i < (swathMetrics.numOfSwathPerGroup.Count()-1); i++)
             {
@@ -66,6 +66,8 @@ namespace SwaMe
                 streamWriter.Write(swathMetrics.swDensity50[i]);
                 streamWriter.Write("\t");
                 streamWriter.Write(swathMetrics.swDensityIQR[i]);
+                streamWriter.Write("\t");
+                streamWriter.Write(swathMetrics.SwathProportionPredictedSingleChargeAvg.ElementAt(i));
                 streamWriter.Write("\n");
             }
             streamWriter.Close();

--- a/SwaMe/SwathGrouper.cs
+++ b/SwaMe/SwathGrouper.cs
@@ -20,9 +20,10 @@ namespace SwaMe
             public List<double> swDensity50;
             public List<double> swDensityIQR;
             public List<double> SwathProportionOfTotalTIC;
+            public List<double> SwathProportionPredictedSingleChargeAvg;
 
             public SwathMetrics(int maxswath, double totalTIC, List<int> numOfSwathPerGroup, List<double> mzRange, List<double> TICs, List<double> swDensity50, List<double> swDensityIQR,
-            List<double> SwathProportionOfTotalTIC)
+            List<double> SwathProportionOfTotalTIC, List<double> SwathProportionPredictedSingleChargeAvg)
             {
                 this.maxswath = maxswath;
                 this.totalTIC = totalTIC;
@@ -32,6 +33,7 @@ namespace SwaMe
                 this.swDensity50 = swDensity50;
                 this.swDensityIQR = swDensityIQR;
                 this.SwathProportionOfTotalTIC = SwathProportionOfTotalTIC;
+                this.SwathProportionPredictedSingleChargeAvg = SwathProportionPredictedSingleChargeAvg;
             }
         }
         public SwathMetrics GroupBySwath(MzmlParser.Run run)
@@ -64,6 +66,9 @@ namespace SwaMe
             List<double> mzTargetRange = new List<double>();
             List<double> medianMzTargetRange = new List<double>();
             List<double> SwathProportionOfTotalTIC = new List<double>();
+            List<double> TotalSwathProportionPredictedSingleCharge = new List<double>();
+            List<double> SwathProportionPredictedSingleChargeAvg = new List<double>();
+
 //Loop through all the swaths of the same number and add to
             for (int swathNumber = 0; swathNumber < swathBoundaries.Count(); swathNumber++)
             {
@@ -78,6 +83,7 @@ namespace SwaMe
                     mzTargetRange.Add(scan.IsolationWindowUpperOffset + scan.IsolationWindowLowerOffset);
                     TICthisSwath = TICthisSwath + scan.TotalIonCurrent;
                     swDensity.Add(scan.Density);
+                    TotalSwathProportionPredictedSingleCharge.Add(scan.proportionChargeStateOne); //The chargestate one's we pick up is where there is a match for M+1. Therefore we need to double it to add the M.
                     track++;
                 }
                 mzTargetRange.Sort();
@@ -85,6 +91,8 @@ namespace SwaMe
                 numOfSwathPerGroup.Add(track);
                 TICs.Add(TICthisSwath);
                 TICthisSwath = 0;
+                SwathProportionPredictedSingleChargeAvg.Add(TotalSwathProportionPredictedSingleCharge.Average());
+                TotalSwathProportionPredictedSingleCharge.Clear();
                 swDensity.Sort();
                 swDensity50.Add(Math.Truncate(Math.Ceiling(swDensity.Average())));
                 swDensityIQR.Add(Math.Truncate(Math.Ceiling(InterQuartileRangeCalculator.CalcIQR(swDensity))));
@@ -96,7 +104,7 @@ namespace SwaMe
                 SwathProportionOfTotalTIC.Add((TICs[num] / totalTIC));
             }
 
-            SwathMetrics swathMetrics = new SwathMetrics(maxswath, totalTIC, numOfSwathPerGroup, mzTargetRange, TICs, swDensity50, swDensityIQR, SwathProportionOfTotalTIC);
+            SwathMetrics swathMetrics = new SwathMetrics(maxswath, totalTIC, numOfSwathPerGroup, mzTargetRange, TICs, swDensity50, swDensityIQR, SwathProportionOfTotalTIC, SwathProportionPredictedSingleChargeAvg);
             return swathMetrics;
         }
 


### PR DESCRIPTION
Working from the premise that M and M+1 pairs are singly charged and the assumption that all peaks that are 1 +- massTolerance apart are M and M+1 pairs; we calculate the difference between each ion in the mz array and each previous ion. 
An array is created of cumulative sums of those differences and each new difference is added to the cumulate of all of the ions before it, until the ion reaches/overshoots 1+-massTolerance. If the cumulative difference is within our range, both the ion to which the cusum belongs and the current ion in the loop is added to a list of matched ions(indexes) and we also stop adding to that ion in future. At the end all the distinct items in indexes are counted and that count is divided by the total amount of floats in the original mzs array to get the proportion.