### PR TITLE
RTDuration calculation left out the very first scan

### DIFF
--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -171,6 +171,8 @@ namespace MzmlParser
                                 break;
                             case "MS:1000016":
                                 scan.Scan.ScanStartTime = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
+                                run.StartTime = Math.Min(run.StartTime, scan.Scan.ScanStartTime);
+                                run.LastScanTime = Math.Max(run.LastScanTime, scan.Scan.ScanStartTime);//technically this is the starttime of the last scan not the completion time
                                 break;
                             
                             case "MS:1000829":
@@ -470,8 +472,6 @@ namespace MzmlParser
 
         private static void FindBasePeaks(Run run, Scan scan)
         {
-            run.StartTime = Math.Min(run.StartTime, scan.ScanStartTime);
-            run.LastScanTime = Math.Max(run.LastScanTime, scan.ScanStartTime);//technically this is the starttime of the last scan not the completion time
             foreach (BasePeak bp in run.BasePeaks.Where(x => Math.Abs(x.Mz - scan.BasePeakMz) <= run.AnalysisSettings.MassTolerance))
             {
                 var temp = bp.BpkRTs.Where(x => Math.Abs(x - scan.ScanStartTime) < run.AnalysisSettings.RtTolerance);


### PR DESCRIPTION
Placed the calculation in a different loop so it can be correctly done. Also just nomalised line endings.

Also removed an unnecessary ceiling and truncate from where new items are added to ms1TICTotal and ms2TICTotal.