### PR TITLE
Changes to deal with non-sequential windows

### DIFF
--- a/SwaMe/RTGrouper.cs
+++ b/SwaMe/RTGrouper.cs
@@ -162,7 +162,7 @@ namespace SwaMe
                 List<int> ms1DensityTemp = new List<int>();
                 List<double> ms1PeakPrecisionTemp = new List<double>();
 
-                foreach (MzmlParser.Scan scan in run.Ms1Scans)
+                foreach (MzmlParser.Scan scan in run.Ms1Scans.OrderBy(x=>x.ScanStartTime))
                 {
                     if (scan.RTsegment == segment)
                     {

--- a/SwaMe/SwathGrouper.cs
+++ b/SwaMe/SwathGrouper.cs
@@ -38,18 +38,10 @@ namespace SwaMe
         }
         public SwathMetrics GroupBySwath(MzmlParser.Run run)
         {
-            int maxswath = 0;
-            var result = run.Ms2Scans.GroupBy(s => s.Cycle).Select(g => new { Count = g.Count() });
-            foreach (var e in result)
-            {
-                if (e.Count > maxswath)
-                    maxswath = e.Count;
-            }
-
+            
             //Create list of target isolationwindows to serve as swathnumber
             List<double> swathBoundaries = new List<double>();
-            swathBoundaries = run.Ms2Scans.Select(x => x.IsolationWindowTargetMz).Distinct().ToList();
-            swathBoundaries.Sort();
+            swathBoundaries = run.Ms2Scans.OrderBy(y=>y.ScanStartTime).Select(x => x.IsolationWindowTargetMz).Distinct().ToList();
             double totalTIC = 0;
             foreach (var scan in run.Ms2Scans)
             {
@@ -104,7 +96,7 @@ namespace SwaMe
                 SwathProportionOfTotalTIC.Add((TICs[num] / totalTIC));
             }
 
-            SwathMetrics swathMetrics = new SwathMetrics(maxswath, totalTIC, numOfSwathPerGroup, mzTargetRange, TICs, swDensity50, swDensityIQR, SwathProportionOfTotalTIC, SwathProportionPredictedSingleChargeAvg);
+            SwathMetrics swathMetrics = new SwathMetrics(swathBoundaries.Count(), totalTIC, numOfSwathPerGroup, mzTargetRange, TICs, swDensity50, swDensityIQR, SwathProportionOfTotalTIC, SwathProportionPredictedSingleChargeAvg);
             return swathMetrics;
         }
 


### PR DESCRIPTION
I found a file where the isolation windows were fixed and the target mzs were in the order 400.83...810.23 then 410.83 ... 820.23, then back to 400.83...810.23. By sorting the isolation windows by the scanstarttime before dividing into swaths and then changing the number of swaths to the total distinct isolation windows rather than the swathnumber of the swath with the largest target ion, I was able to keep the configuration and not order the swaths 400.83, 410.83 etc. as well as including all swaths even if their  isolation target mz is smaller than the previous swath.