### PR TITLE
Add test stanza to build script

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,5 +17,7 @@ jobs:
         dotnet-version: 2.2.108
     - name: Build with dotnet
       run: dotnet build --configuration Release
+    - name: Test LibraryParser
+      run: dotnet test LibraryParser.Test/LibraryParser.Test.csproj --configuration Release
 
     


### PR DESCRIPTION
This presently just runs tests in the single available test project (LibraryParser), but it should be reasonably obvious how to extend.  As the files required to make the tests pass aren't distributed with the test project (tut tut :-) ) then many of the tests fail; I suggest committing appropriate, preferably small, test data.