### PR TITLE
Make generic mzml reader

### DIFF
--- a/Console/Program.cs
+++ b/Console/Program.cs
@@ -84,7 +84,7 @@ namespace Yamato.Console
                         TraMLReader traMLReader = new TraMLReader();
                         analysisSettings.IrtLibrary = traMLReader.LoadLibrary(options.IRTFile);
                     }
-                    MzmlParser.Run run = mzmlParser.LoadMzml(inputFilePath, irt, analysisSettings);
+                    Run run = mzmlParser.LoadMzml(inputFilePath, analysisSettings);
 
                     run = new MzmlParser.ChromatogramGenerator().CreateAllChromatograms(run);
                     new SwaMe.MetricGenerator().GenerateMetrics(run, division, inputFilePath, irt, combine, lastFile, dateTime);

--- a/MzmlReader/GenericMzmlReader.cs
+++ b/MzmlReader/GenericMzmlReader.cs
@@ -1,0 +1,365 @@
+using NLog;
+using System;
+using System.Xml;
+using System.Linq;
+using System.Globalization;
+using Ionic.Zlib;
+using System.IO;
+
+namespace MzmlParser
+{
+    public abstract class GenericMzmlReader<TRun, TScan>
+        where TRun : IGenericRun<TScan>, new()
+        where TScan : IGenericScan, new()
+    {
+        public GenericMzmlReader()
+        {
+            ParseBinaryData = true;
+            Threading = true;
+        }
+
+        public bool ParseBinaryData { get; set; }
+        public bool Threading { get; set; }
+
+        private int currentCycle = 0;
+        bool MS1 = false;
+        private double previousTargetMz = 0;
+
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+        private string SurveyScanReferenceableParamGroupId; //This is the referenceableparamgroupid for the survey scan
+
+        protected abstract void ParseBase64DataFilling(TScan scan, TRun run);
+
+        protected void ReadMzml(string path, TRun run)
+        {
+            ICouldRunCodeInParallel runner = Threading
+                ? (ICouldRunCodeInParallel)new ThreadPoolScheduler()
+                : new SingleThreadedScheduler();
+            using (XmlReader reader = XmlReader.Create(path))
+            {
+                while (reader.Read())
+                {
+                    if (reader.IsStartElement())
+                    {
+                        switch (reader.LocalName)
+                        {
+                            case "sourceFile":
+                                ReadSourceFileMetaData(reader, run);
+                                break;
+                            case "spectrum":
+                                ReadSpectrum(reader, run, runner);
+                                break;
+                            case "referenceableParamGroup":
+                                if (string.IsNullOrEmpty(SurveyScanReferenceableParamGroupId))
+                                    SurveyScanReferenceableParamGroupId = reader.GetAttribute("id");
+                                break;
+                        }
+                    }
+                }
+            }
+            runner.WaitForAll();
+        }
+
+        private void ReadSourceFileMetaData(XmlReader reader, TRun run)
+        {
+            bool cvParamsRead = false;
+            run.SourceFileName = Path.GetFileNameWithoutExtension(reader.GetAttribute("name"));
+            if (run.SourceFileName.ToLower().EndsWith(".wiff")) //in a .wiff.scan file you need to remove both extensions
+            {
+                run.SourceFileName = Path.GetFileNameWithoutExtension(run.SourceFileName);
+            }
+            run.SourceFileType = Path.GetExtension(reader.GetAttribute("name"));
+            run.SourceFilePath = reader.GetAttribute("location");
+
+            while (reader.Read() && !cvParamsRead)
+            {
+                if (reader.IsStartElement())
+                {
+                    if (reader.LocalName == "cvParam")
+                    {
+                        switch (reader.GetAttribute("accession"))
+                        {
+                            case "MS:1000569":
+                                run.SourceFileChecksum = reader.GetAttribute("value");
+                                run.FilePropertiesAccession = "MS:1000569";
+                                break;
+                            case "MS:1000747"://Optional for the conversion process, but included in mzQC
+                                run.CompletionTime = reader.GetAttribute("value");
+                                break;
+                        }
+                    }
+                }
+                else if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "sourceFile")
+                {
+                    cvParamsRead = true;
+                }
+            }
+        }
+
+        private void ReadSpectrum(XmlReader reader, TRun run, ICouldRunCodeInParallel runner)
+        {
+            ScanAndTempProperties scan = new ScanAndTempProperties();
+
+            //The cycle number is within a kvp string in the following format: "sample=1 period=1 cycle=1 experiment=1"
+            //
+            //This is a bit code-soup but I didn't want to spend more than one line on it and it should be robust enough not just to select on index
+            //
+            //This has only been tested on Sciex converted data
+            //
+            //Paul Brack 2019/04/03
+
+            bool CycleInfoInID = false;
+
+            if (run.SourceFileType.EndsWith("wiff", StringComparison.InvariantCultureIgnoreCase) || run.SourceFileType.ToUpper().EndsWith("scan", StringComparison.InvariantCultureIgnoreCase))
+            {
+                scan.Scan.Cycle = int.Parse(reader.GetAttribute("id").Split(' ').Single(x => x.Contains("cycle")).Split('=').Last());
+                if (scan.Scan.Cycle != 0)//Some wiffs don't have that info so let's check
+                {
+                    CycleInfoInID = true;
+                }
+            }
+
+            bool cvParamsRead = false;
+            while (reader.Read() && !cvParamsRead)
+            {
+                if (reader.IsStartElement())
+                {
+                    if (reader.LocalName == "cvParam")
+                    {
+                        switch (reader.GetAttribute("accession"))
+                        {
+
+                            case "MS:1000511":
+                                scan.Scan.MsLevel = int.Parse(reader.GetAttribute("value"));
+                                break;
+                            case "MS:1000285":
+                                scan.Scan.TotalIonCurrent = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
+                                break;
+                            case "MS:1000016":
+                                scan.Scan.ScanStartTime = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
+                                run.StartTime = Math.Min(run.StartTime, scan.Scan.ScanStartTime);
+                                run.LastScanTime = Math.Max(run.LastScanTime, scan.Scan.ScanStartTime);//technically this is the starttime of the last scan not the completion time
+                                break;
+
+                            case "MS:1000829":
+                                scan.Scan.IsolationWindowUpperOffset = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
+                                break;
+                            case "MS:1000828":
+                                scan.Scan.IsolationWindowLowerOffset = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
+                                break;
+                            case "MS:1000827":
+                                scan.Scan.IsolationWindowTargetMz = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
+                                break;
+
+                        }
+                    }
+                    else if (reader.LocalName == "binaryDataArray")
+                    {
+                        GetBinaryData(reader, scan);
+                    }
+                    else if (scan.Scan.MsLevel == null && reader.LocalName == "referenceableParamGroupRef")
+                    {
+                        if (reader.GetAttribute("ref") == SurveyScanReferenceableParamGroupId)
+                            scan.Scan.MsLevel = 1;
+                        else
+                            scan.Scan.MsLevel = 2;
+                    }
+                }
+                else if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "spectrum")
+                {
+
+                    if (!CycleInfoInID)
+                    {
+                        if (scan.Scan.MsLevel == 1)
+                        {
+                            currentCycle++;
+                            scan.Scan.Cycle = currentCycle;
+                            MS1 = true;
+                        }
+                        //if there is ScanAndTempProperties ms1:
+                        else if (MS1)
+                        {
+                            scan.Scan.Cycle = currentCycle;
+                        }
+                        //if there is no ms1:
+                        else
+                        {
+                            if (previousTargetMz < scan.Scan.IsolationWindowTargetMz)
+                            {
+                                scan.Scan.Cycle = currentCycle;
+                            }
+                            else
+                            {
+                                currentCycle++;
+                                scan.Scan.Cycle = currentCycle;
+                            }
+                        }
+                    }
+
+                    previousTargetMz = scan.Scan.IsolationWindowTargetMz;
+
+                    if (ParseBinaryData)
+                        runner.Submit(state => ParseBase64Data(scan, run));
+                    else
+                        AddScanToRun(scan.Scan, run);
+                    cvParamsRead = true;
+                }
+            }
+        }
+
+        private static void GetBinaryData(XmlReader reader, ScanAndTempProperties scan)
+        {
+            string base64 = string.Empty;
+            int bits = 0;
+            bool intensityArray = false;
+            bool mzArray = false;
+            bool binaryDataArrayRead = false;
+            bool IsZlibCompressed = false;
+
+            while (reader.Read() && binaryDataArrayRead == false)
+            {
+                if (reader.IsStartElement())
+                {
+                    if (reader.LocalName == "cvParam")
+                    {
+                        switch (reader.GetAttribute("accession"))
+                        {
+                            case "MS:1000574":
+                                if (reader.GetAttribute("name") == "zlib compression")
+                                    IsZlibCompressed = true;
+                                break;
+                            case "MS:1000521":
+                                //32 bit float
+                                bits = 32;
+                                break;
+                            case "MS:1000523":
+                                //64 bit float
+                                bits = 64;
+                                break;
+                            case "MS:1000515":
+                                //intensity array
+                                intensityArray = true;
+                                break;
+                            case "MS:1000514":
+                                //mz array
+                                mzArray = true;
+                                break;
+                        }
+                    }
+                    else if (reader.LocalName == "binary")
+                    {
+                        base64 = reader.ReadElementContentAsString();
+                    }
+
+                }
+                if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "binaryDataArray")
+                {
+                    binaryDataArrayRead = true;
+                    if (intensityArray)
+                    {
+                        scan.Base64IntensityArray = base64;
+                        scan.IntensityBitLength = bits;
+                        scan.IntensityZlibCompressed = IsZlibCompressed;
+                    }
+                    else if (mzArray)
+                    {
+                        scan.Base64MzArray = base64;
+                        scan.MzBitLength = bits;
+                        scan.MzZlibCompressed = IsZlibCompressed;
+                    }
+                }
+            }
+        }
+
+        private void ParseBase64Data(ScanAndTempProperties scan, TRun run)
+        {
+
+            float[] intensities = ExtractFloatArray(scan.Base64IntensityArray, scan.IntensityZlibCompressed, scan.IntensityBitLength);
+            float[] mzs = ExtractFloatArray(scan.Base64MzArray, scan.MzZlibCompressed, scan.MzBitLength);
+
+            if (intensities.Count() == 0)
+            {
+                intensities = ZeroArray();
+                mzs = ZeroArray();
+                logger.Info("Empty binary array for a MS{0} scan in cycle number: {0}. The empty scans have been filled with zero values.", scan.Scan.MsLevel, scan.Scan.Cycle);
+                run.MissingScans++;
+            }
+            var spectrum = intensities.Select((x, i) => new SpectrumPoint() { Intensity = x, Mz = mzs[i], RetentionTime = (float)scan.Scan.ScanStartTime }).ToList();
+            scan.Scan.Spectrum = spectrum;
+            scan.Scan.IsolationWindowLowerBoundary = scan.Scan.IsolationWindowTargetMz - scan.Scan.IsolationWindowLowerOffset;
+            scan.Scan.IsolationWindowUpperBoundary = scan.Scan.IsolationWindowTargetMz + scan.Scan.IsolationWindowUpperOffset;
+
+            scan.Scan.Density = spectrum.Count();
+            scan.Scan.BasePeakIntensity = intensities.Max();
+            scan.Scan.BasePeakMz = mzs[Array.IndexOf(intensities, intensities.Max())];
+            AddScanToRun(scan.Scan, run);
+
+            ParseBase64DataFilling(scan.Scan, run);
+        }
+
+        private static float[] ExtractFloatArray(string Base64Array, bool IsZlibCompressed, int bits)
+        {
+            byte[] bytes = Convert.FromBase64String(Base64Array);
+
+            if (IsZlibCompressed)
+                bytes = ZlibStream.UncompressBuffer(bytes);
+
+            if (bits == 32)
+                return GetFloats(bytes);
+            else if (bits == 64)
+                return GetFloatsFromDoubles(bytes);
+            else
+                throw new ArgumentOutOfRangeException("bits", "Numbers must be 32 or 64 bits");
+        }
+
+        private static float[] GetFloats(byte[] bytes)
+        {
+            float[] floats = new float[bytes.Length / 4];
+            for (int i = 0; i < floats.Length; i++)
+                floats[i] = BitConverter.ToSingle(bytes, i * 4);
+            return floats;
+        }
+
+        private static float[] GetFloatsFromDoubles(byte[] bytes)
+        {
+            float[] floats = new float[bytes.Length / 8];
+            for (int i = 0; i < floats.Length; i++)
+                floats[i] = (float)BitConverter.ToDouble(bytes, i * 8);
+            return floats;
+        }
+
+        private static void AddScanToRun(TScan scan, TRun run)
+        {
+            scan.IsolationWindowLowerBoundary = scan.IsolationWindowTargetMz - scan.IsolationWindowLowerOffset;
+            scan.IsolationWindowUpperBoundary = scan.IsolationWindowTargetMz + scan.IsolationWindowUpperOffset;
+
+            if (scan.MsLevel == 1)
+                run.Ms1Scans.Add(scan);
+            else if (scan.MsLevel == 2)
+                run.Ms2Scans.Add(scan);
+            else
+                throw new ArgumentOutOfRangeException("scan.MsLevel", "MS Level must be 1 or 2");
+        }
+
+        private static float[] ZeroArray()
+        {
+            return new float[5];
+        }
+
+        private class ScanAndTempProperties
+        {
+            public ScanAndTempProperties()
+            {
+                Scan = new TScan();
+            }
+
+            public TScan Scan { get; set; }
+            public string Base64IntensityArray { get; set; }
+            public string Base64MzArray { get; set; }
+            public bool IntensityZlibCompressed { get; set; }
+            public bool MzZlibCompressed { get; set; }
+            public int IntensityBitLength { get; set; }
+            public int MzBitLength { get; set; }
+        }
+    }
+}

--- a/MzmlReader/GenericMzmlReader.cs
+++ b/MzmlReader/GenericMzmlReader.cs
@@ -12,17 +12,11 @@ namespace MzmlParser
         where TRun : IGenericRun<TScan>, new()
         where TScan : IGenericScan, new()
     {
-        public GenericMzmlReader()
-        {
-            ParseBinaryData = true;
-            Threading = true;
-        }
-
-        public bool ParseBinaryData { get; set; }
-        public bool Threading { get; set; }
+        public bool ParseBinaryData { get; set; } = true;
+        public bool Threading { get; set; } = true;
 
         private int currentCycle = 0;
-        bool MS1 = false;
+        bool hasAtLeastOneMS1 = false;
         private double previousTargetMz = 0;
 
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
@@ -174,10 +168,10 @@ namespace MzmlParser
                         {
                             currentCycle++;
                             scan.Scan.Cycle = currentCycle;
-                            MS1 = true;
+                            hasAtLeastOneMS1 = true;
                         }
                         //if there is ScanAndTempProperties ms1:
-                        else if (MS1)
+                        else if (hasAtLeastOneMS1)
                         {
                             scan.Scan.Cycle = currentCycle;
                         }
@@ -250,7 +244,6 @@ namespace MzmlParser
                     {
                         base64 = reader.ReadElementContentAsString();
                     }
-
                 }
                 if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "binaryDataArray")
                 {
@@ -273,7 +266,6 @@ namespace MzmlParser
 
         private void ParseBase64Data(ScanAndTempProperties scan, TRun run)
         {
-
             float[] intensities = ExtractFloatArray(scan.Base64IntensityArray, scan.IntensityZlibCompressed, scan.IntensityBitLength);
             float[] mzs = ExtractFloatArray(scan.Base64MzArray, scan.MzZlibCompressed, scan.MzBitLength);
 

--- a/MzmlReader/IAnalysisSettings.cs
+++ b/MzmlReader/IAnalysisSettings.cs
@@ -1,0 +1,15 @@
+﻿using LibraryParser;
+
+namespace MzmlParser
+{
+    public interface IAnalysisSettings
+    {
+        double MassTolerance { get; set; }
+        double RtTolerance { get; set; }
+        Library IrtLibrary { get; set; }
+        double IrtMassTolerance { get; set; }
+        double IrtMinIntensity { get; set; }
+        int IrtMinPeptides { get; set; }
+        void SetGlobalMassTolerance(int tolerance);
+    }
+}

--- a/MzmlReader/IChromatograms.cs
+++ b/MzmlReader/IChromatograms.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace MzmlParser
+{
+    public interface IChromatograms
+    {
+        IList<(double, double)> Ms1Tic { get; set; }
+        IList<(double, double)> Ms2Tic { get; set; }
+        IList<(double, double)> Ms1Bpc { get; set; }
+        IList<(double, double)> Ms2Bpc { get; set; }
+    }
+}

--- a/MzmlReader/ICouldRunCodeInParallel.cs
+++ b/MzmlReader/ICouldRunCodeInParallel.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading;
+
+namespace MzmlParser
+{
+    /// <summary>
+    /// A convenient interface to implement work that might be run in serial or parallel depending on the implementation.
+    /// To use: instantiate an appropriate class, keep submitting work via Submit (which might run immediately or be scheduled), then call WaitForAll which will return only when all work is completed.
+    /// </summary>
+    public interface ICouldRunCodeInParallel
+    {
+        void Submit(WaitCallback callback);
+        void WaitForAll();
+    }
+}

--- a/MzmlReader/IGenericRun.cs
+++ b/MzmlReader/IGenericRun.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace MzmlParser
+{
+    public interface IGenericRun<TScan>
+        where TScan: IGenericScan
+    {
+        double StartTime { get; set; }
+        double LastScanTime { get; set; }
+        string SourceFileType { get; set; }
+        string SourceFileName { get; set; }
+        string SourceFilePath { get; set; }
+        string SourceFileChecksum { get; set; }
+        string CompletionTime { get; set; }
+        IList<TScan> Ms1Scans { get; set; }
+        ConcurrentBag<TScan> Ms2Scans { get; set; }
+        Chromatograms Chromatograms { get; set; }
+        IList<(double, double)> IsolationWindows { get; set; }
+        int MissingScans { get; set; }
+        string FilePropertiesAccession { get; set; }
+        AnalysisSettings AnalysisSettings { get; set; }
+    }
+}

--- a/MzmlReader/IGenericScan.cs
+++ b/MzmlReader/IGenericScan.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace MzmlParser
+{
+    public interface IGenericScan
+    {
+        int Cycle { get; set; }
+        int? MsLevel { get; set; }
+        double BasePeakIntensity { get; set; }
+        double BasePeakMz { get; set; }
+        double TotalIonCurrent { get; set; }
+        double ScanStartTime { get; set; }
+        double IsolationWindowTargetMz { get; set; }
+        double IsolationWindowUpperOffset { get; set; }
+        double IsolationWindowLowerOffset { get; set; }
+        double IsolationWindowUpperBoundary { get; set; }
+        double IsolationWindowLowerBoundary { get; set; }
+        int RTsegment { get; set; }
+        int Density { get; set; }
+        IList<SpectrumPoint> Spectrum { get; set; }
+    }
+}

--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -43,6 +43,8 @@ namespace MzmlParser
                 double mz = scan.BasePeakMz;
 
                 // TODO: BEWARE: There is a race condition here, as the check-and-add is not atomic.
+                // TODO: We could reduce the chance of the race by using Any() rather than Count() here, as that will quit on first match and hence be faster.
+                // TODO: We could eliminate the race completely by wrapping the check down to the add in a lock - need to be careful about the matched arm.
                 if (run.BasePeaks.Count(x => Math.Abs(x.Mz - mz) < run.AnalysisSettings.MassTolerance) < 1)//If a basepeak with this mz doesn't exist yet add it
                 {
                     BasePeak bp = new BasePeak(mz, scan.ScanStartTime, scan.BasePeakIntensity);

--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -1,27 +1,23 @@
 using System;
 using System.Linq;
-using System.Threading;
 using System.Collections.Generic;
 using LibraryParser;
 
 namespace MzmlParser
 {
-
     public class MzmlReader : GenericMzmlReader<Run, Scan>
     {
-        public MzmlReader()
-        {
-            ExtractBasePeaks = true;
-        }
-
-        public bool ExtractBasePeaks { get; set; }
+        public bool ExtractBasePeaks { get; set; } = true;
 
         public Run LoadMzml(string path, AnalysisSettings analysisSettings)
         {
-            Run run = new Run() { AnalysisSettings = analysisSettings };
-            run.MissingScans = 0;
-            run.StartTime = 100;
-            run.LastScanTime = 0;
+            Run run = new Run()
+            {
+                AnalysisSettings = analysisSettings,
+                MissingScans = 0,
+                StartTime = 100,
+                LastScanTime = 0
+            };
 
             ReadMzml(path, run);
 

--- a/MzmlReader/MzmlReader.cs
+++ b/MzmlReader/MzmlReader.cs
@@ -1,398 +1,55 @@
-using NLog;
 using System;
-using System.Xml;
 using System.Linq;
-using System.Globalization;
 using System.Threading;
-using Ionic.Zlib;
-using System.IO;
 using System.Collections.Generic;
 using LibraryParser;
 
 namespace MzmlParser
 {
 
-    public class MzmlReader
+    public class MzmlReader : GenericMzmlReader<Run, Scan>
     {
         public MzmlReader()
         {
-            ParseBinaryData = true;
             ExtractBasePeaks = true;
-            Threading = true;
         }
 
         public bool ExtractBasePeaks { get; set; }
-        public bool ParseBinaryData { get; set; }
-        public bool Threading { get; set; }
 
-        private const double BasePeakMinimumIntensity = 100;
-        public int currentCycle = 0;
-        bool MS1 = false;
-        public double previousTargetMz = 0;
-
-        private static Logger logger = LogManager.GetCurrentClassLogger();
-        private static CountdownEvent cde = new CountdownEvent(1);
-        private static readonly Object Lock = new Object();
-        private string SurveyScanReferenceableParamGroupId; //This is the referenceableparamgroupid for the survey scan
-
-        public Run LoadMzml(string path, bool storeScansInMemory, AnalysisSettings analysisSettings)
+        public Run LoadMzml(string path, AnalysisSettings analysisSettings)
         {
             Run run = new Run() { AnalysisSettings = analysisSettings };
-            bool irt = run.AnalysisSettings.IrtLibrary != null;
             run.MissingScans = 0;
             run.StartTime = 100;
             run.LastScanTime = 0;
 
-            ReadMzml(path, run, irt);
-
-            cde.Signal();
-            cde.Wait();
-            cde.Reset(1);
+            ReadMzml(path, run);
 
             AddBasePeakSpectra(run);
 
-            cde.Signal();
-            cde.Wait();
-            cde.Reset(1);
             IrtPeptideMatcher.ChooseIrtPeptides(run);
 
             return run;
         }
 
-        private void ReadMzml(string path, Run run, bool irt)
+        protected override void ParseBase64DataFilling(Scan scan, Run run)
         {
-            using (XmlReader reader = XmlReader.Create(path))
-            {
-                while (reader.Read())
-                {
-                    if (reader.IsStartElement())
-                    {
-                        switch (reader.LocalName)
-                        {
-                            case "sourceFile":
-                                ReadSourceFileMetaData(reader, run);
-                                break;
-                            case "spectrum":
-                                ReadSpectrum(reader, run, irt);
-                                break;
-                            case "referenceableParamGroup":
-                                if (String.IsNullOrEmpty(SurveyScanReferenceableParamGroupId))
-                                    SurveyScanReferenceableParamGroupId = reader.GetAttribute("id");
-                                break;
-                        }
-                    }
-                }
-            }
+            PredictSinglyChargedProportion(scan);
+            CheckBasePeakForScan(scan, run);
+            if (null != run.AnalysisSettings.IrtLibrary)
+                FindIrtPeptideCandidates(scan, run);
         }
 
-
-        public void AddInfoToBasePeaks(Run run, QuickScan qs)
+        private static void CheckBasePeakForScan(Scan scan, Run run)
         {
-            float[] intensities = ExtractFloatArray(qs.Base64IntensityArray, qs.IntensityZlibCompressed, qs.IntensityBitLength);
-            float[] mzs = ExtractFloatArray(qs.Base64MzArray, qs.MzZlibCompressed, qs.MzBitLength);
-
-
-        }
-
-        public void ReadSourceFileMetaData(XmlReader reader, Run run)
-        {
-            bool cvParamsRead = false;
-            run.SourceFileName = Path.GetFileNameWithoutExtension(reader.GetAttribute("name"));
-            if (run.SourceFileName.ToLower().EndsWith(".wiff"))//in a .wiff.scan file you need to remove both extensions
+            if (scan.Spectrum.Count() > 0)
             {
-                run.SourceFileName = Path.GetFileNameWithoutExtension(run.SourceFileName);
-            }
-            run.SourceFileType = Path.GetExtension(reader.GetAttribute("name"));
-            run.SourceFilePath = reader.GetAttribute("location");
+                double mz = scan.BasePeakMz;
 
-            while (reader.Read() && !cvParamsRead)
-            {
-                if (reader.IsStartElement())
-                {
-                    if (reader.LocalName == "cvParam")
-                    {
-                        switch (reader.GetAttribute("accession"))
-                        {
-                            case "MS:1000569":
-                                run.SourceFileChecksum = reader.GetAttribute("value");
-                                run.FilePropertiesAccession = "MS:1000569";
-                                break;
-                            case "MS:1000747"://Optional for the conversion process, but included in mzQC
-                                run.CompletionTime = reader.GetAttribute("value");
-                                break;
-                        }
-                    }
-                }
-                else if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "sourceFile")
-                {
-                    cvParamsRead = true;
-                }
-            }
-        }
-
-        public void ReadSpectrum(XmlReader reader, Run run, bool irt)
-        {
-            ScanAndTempProperties scan = new ScanAndTempProperties();
-
-            //The cycle number is within a kvp string in the following format: "sample=1 period=1 cycle=1 experiment=1"
-            //
-            //This is a bit code-soup but I didn't want to spend more than one line on it and it should be robust enough not just to select on index
-            //
-            //This has only been tested on Sciex converted data
-            //
-            //Paul Brack 2019/04/03
-
-            bool CycleInfoInID = false;
-
-            if (run.SourceFileType.EndsWith("wiff", StringComparison.InvariantCultureIgnoreCase) || run.SourceFileType.ToUpper().EndsWith("scan", StringComparison.InvariantCultureIgnoreCase))
-            {
-                scan.Scan.Cycle = int.Parse(reader.GetAttribute("id").Split(' ').Single(x => x.Contains("cycle")).Split('=').Last());
-                if (scan.Scan.Cycle != 0)//Some wiffs don't have that info so let's check
-                {
-                    CycleInfoInID = true;
-                }
-            }
-
-            bool cvParamsRead = false;
-            while (reader.Read() && !cvParamsRead)
-            {
-                if (reader.IsStartElement())
-                {
-                    if (reader.LocalName == "cvParam")
-                    {
-                        switch (reader.GetAttribute("accession"))
-                        {
-
-                            case "MS:1000511":
-                                scan.Scan.MsLevel = int.Parse(reader.GetAttribute("value"));
-                                break;
-                            case "MS:1000285":
-                                scan.Scan.TotalIonCurrent = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
-                                break;
-                            case "MS:1000016":
-                                scan.Scan.ScanStartTime = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
-                                run.StartTime = Math.Min(run.StartTime, scan.Scan.ScanStartTime);
-                                run.LastScanTime = Math.Max(run.LastScanTime, scan.Scan.ScanStartTime);//technically this is the starttime of the last scan not the completion time
-                                break;
-                            
-                            case "MS:1000829":
-                                scan.Scan.IsolationWindowUpperOffset = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
-                                break;
-                            case "MS:1000828":
-                                scan.Scan.IsolationWindowLowerOffset = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
-                                break;
-                            case "MS:1000827":
-                                scan.Scan.IsolationWindowTargetMz = double.Parse(reader.GetAttribute("value"), CultureInfo.InvariantCulture);
-                                break;
-
-                        }
-                    }
-                    else if (reader.LocalName == "binaryDataArray")
-                    {
-                        GetBinaryData(reader, scan);
-                    }
-                    if (scan.Scan.MsLevel == null && reader.LocalName == "referenceableParamGroupRef")
-                    {
-                        if (reader.GetAttribute("ref") == SurveyScanReferenceableParamGroupId)
-                            scan.Scan.MsLevel = 1;
-                        else
-                            scan.Scan.MsLevel = 2;
-                    }
-                }
-                else if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "spectrum")
-                {
-
-                    if (!CycleInfoInID)
-                    {
-                        if (scan.Scan.MsLevel == 1)
-                        {
-                            currentCycle++;
-                            scan.Scan.Cycle = currentCycle;
-                            MS1 = true;
-                        }
-                        //if there is ScanAndTempProperties ms1:
-                        else if (MS1)
-                        {
-                            scan.Scan.Cycle = currentCycle;
-                        }
-                        //if there is no ms1:
-                        else
-                        {
-                            if (previousTargetMz < scan.Scan.IsolationWindowTargetMz)
-                            {
-                                scan.Scan.Cycle = currentCycle;
-                            }
-                            else
-                            {
-                                currentCycle ++;
-                                scan.Scan.Cycle = currentCycle;
-                            }
-                        }
-                    }
-
-                    previousTargetMz = scan.Scan.IsolationWindowTargetMz;
-
-                    if (ParseBinaryData)
-                    {
-                        if (Threading)
-                        {
-                            cde.AddCount();
-                            ThreadPool.QueueUserWorkItem(state => ParseBase64Data(scan, run, ExtractBasePeaks, Threading, irt));
-                        }
-                        else
-                        {
-                            ParseBase64Data(scan, run, ExtractBasePeaks, Threading, irt);
-                        }
-                    }
-                    else
-                    {
-                        AddScanToRun(scan.Scan, run);
-                    }
-                    cvParamsRead = true;
-
-                }
-            }
-        }
-
-        private static void GetBinaryData(XmlReader reader, ScanAndTempProperties scan)
-        {
-            string base64 = String.Empty;
-            int bits = 0;
-            bool intensityArray = false;
-            bool mzArray = false;
-            bool binaryDataArrayRead = false;
-            bool IsZlibCompressed = false;
-
-            while (reader.Read() && binaryDataArrayRead == false)
-            {
-                if (reader.IsStartElement())
-                {
-                    if (reader.LocalName == "cvParam")
-                    {
-                        switch (reader.GetAttribute("accession"))
-                        {
-                            case "MS:1000574":
-                                if (reader.GetAttribute("name") == "zlib compression")
-                                    IsZlibCompressed = true;
-                                break;
-                            case "MS:1000521":
-                                //32 bit float
-                                bits = 32;
-                                break;
-                            case "MS:1000523":
-                                //64 bit float
-                                bits = 64;
-                                break;
-                            case "MS:1000515":
-                                //intensity array
-                                intensityArray = true;
-                                break;
-                            case "MS:1000514":
-                                //mz array
-                                mzArray = true;
-                                break;
-                        }
-                    }
-                    else if (reader.LocalName == "binary")
-                    {
-                        base64 = reader.ReadElementContentAsString();
-                    }
-
-                }
-                if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "binaryDataArray")
-                {
-                    binaryDataArrayRead = true;
-                    if (intensityArray)
-                    {
-                        scan.Base64IntensityArray = base64;
-                        scan.IntensityBitLength = bits;
-                        scan.IntensityZlibCompressed = IsZlibCompressed;
-                    }
-                    else if (mzArray)
-                    {
-                        scan.Base64MzArray = base64;
-                        scan.MzBitLength = bits;
-                        scan.MzZlibCompressed = IsZlibCompressed;
-                    }
-                }
-            }
-        }
-
-        private static void ParseBase64Data(ScanAndTempProperties scan, Run run, bool extractBasePeaks, bool threading, bool irt)
-        {
-
-            float[] intensities = ExtractFloatArray(scan.Base64IntensityArray, scan.IntensityZlibCompressed, scan.IntensityBitLength);
-            float[] mzs = ExtractFloatArray(scan.Base64MzArray, scan.MzZlibCompressed, scan.MzBitLength);
-
-            if (intensities.Count() == 0)
-            {
-                intensities = FillZeroArray(intensities);
-                mzs = FillZeroArray(mzs);
-                logger.Info("Empty binary array for a MS{0} scan in cycle number: {0}. The empty scans have been filled with zero values.", scan.Scan.MsLevel, scan.Scan.Cycle);
-                run.MissingScans++;
-            }
-            var spectrum = intensities.Select((x, i) => new SpectrumPoint() { Intensity = x, Mz = mzs[i], RetentionTime = (float)scan.Scan.ScanStartTime }).ToList();
-
-
-            //Predicted singly charged proportion:
-
-            //The theory is that an M and M+1 pair are singly charged so we are very simply just looking for  occurences where two ions are 1 mz apart (+-massTolerance)
-
-            //We therefore create an array cusums that accumulates the difference between ions, so for every ion we calculate the distance between that ion
-            //and the previous and add that to each of the previous ions' cusum of differences. If the cusum of an ion overshoots 1 +massTolerance, we stop adding to it, if it reaches our mark we count it and stop adding to it
-
-            List<int> indexes = new List<int>();
-            float[] cusums = new float[mzs.Length];
-            int movingPoint = 0;
-            double minimum = 1 - 0.001;
-            double maximum = 1 + 0.001;
-
-            for (int i = 1; i < mzs.Length; i++)
-            {
-                float distance = mzs[i] - mzs[i - 1];
-                bool matchedWithLower = false;
-                for (int ii = movingPoint; ii < i; ii++)
-                {
-                    cusums[ii] += distance;
-                    if (cusums[ii] < minimum) continue;
-                    else if (cusums[ii] > minimum && cusums[ii] < maximum)
-                    {
-                        if (!matchedWithLower)//This is to try and minimise false positives where for example if you have an array: 351.14, 351.15, 352.14 all three get chosen.
-                        {
-                            indexes.Add(i);
-                            indexes.Add(movingPoint);
-                        }
-                        movingPoint +=1;
-                        matchedWithLower = true;
-                        continue;
-                    }
-                    else if (cusums[ii] > maximum) { movingPoint += 1; }
-                }
-
-            }
-            int distinct = indexes.Distinct().Count();
-            int len = mzs.Length;
-            scan.Scan.proportionChargeStateOne = (double)distinct/(double)len;
-
-            
-            scan.Scan.Spectrum = spectrum;
-            scan.Scan.IsolationWindowLowerBoundary = scan.Scan.IsolationWindowTargetMz - scan.Scan.IsolationWindowLowerOffset;
-            scan.Scan.IsolationWindowUpperBoundary = scan.Scan.IsolationWindowTargetMz + scan.Scan.IsolationWindowUpperOffset;
-
-            scan.Scan.Density = spectrum.Count();
-            scan.Scan.BasePeakIntensity = intensities.Max();
-            scan.Scan.BasePeakMz = mzs[Array.IndexOf(intensities, intensities.Max())];
-            AddScanToRun(scan.Scan, run);
-            float basepeakIntensity;
-            if (intensities.Count() > 0)
-            {
-                basepeakIntensity = intensities.Max();
-                int maxIndex = intensities.ToList().IndexOf(basepeakIntensity);
-                double mz = mzs[maxIndex];
-
+                // TODO: BEWARE: There is a race condition here, as the check-and-add is not atomic.
                 if (run.BasePeaks.Count(x => Math.Abs(x.Mz - mz) < run.AnalysisSettings.MassTolerance) < 1)//If a basepeak with this mz doesn't exist yet add it
                 {
-                    BasePeak bp = new BasePeak(mz, scan.Scan.ScanStartTime, basepeakIntensity);
+                    BasePeak bp = new BasePeak(mz, scan.ScanStartTime, scan.BasePeakIntensity);
                     run.BasePeaks.Add(bp);
                 }
                 else //we do have a match, now lets figure out if they fall within the rtTolerance
@@ -403,7 +60,7 @@ namespace MzmlParser
                         bool found = false;
                         for (int rt = 0; rt < thisbp.BpkRTs.Count(); rt++)
                         {
-                            if (Math.Abs(thisbp.BpkRTs[rt] - scan.Scan.ScanStartTime) < run.AnalysisSettings.RtTolerance)//this is part of a previous basepeak, or at least considered to be 
+                            if (Math.Abs(thisbp.BpkRTs[rt] - scan.ScanStartTime) < run.AnalysisSettings.RtTolerance)//this is part of a previous basepeak, or at least considered to be 
                             {
                                 found = true;
                                 break;
@@ -412,23 +69,62 @@ namespace MzmlParser
                         }
                         if (!found)//This is considered to be a new instance
                         {
-                            thisbp.BpkRTs.Add(scan.Scan.ScanStartTime);
-                            thisbp.Intensities.Add(basepeakIntensity);
+                            thisbp.BpkRTs.Add(scan.ScanStartTime);
+                            thisbp.Intensities.Add(scan.BasePeakIntensity);
                         }
                     }
                 }
             }
-            else { basepeakIntensity = 0; }
             //Extract info for Basepeak chromatograms
-
-            if (irt)
-                FindIrtPeptideCandidates(scan, run, spectrum);
-
-            if (threading)
-                cde.Signal();
         }
 
-        private static void FindIrtPeptideCandidates(ScanAndTempProperties scan, Run run, List<SpectrumPoint> spectrum)
+        private static void PredictSinglyChargedProportion(Scan scan)
+        {
+            //Predicted singly charged proportion:
+
+            //The theory is that an M and M+1 pair are singly charged so we are very simply just looking for  occurences where two ions are 1 mz apart (+-massTolerance)
+
+            //We therefore create an array cusums that accumulates the difference between ions, so for every ion we calculate the distance between that ion
+            //and the previous and add that to each of the previous ions' cusum of differences. If the cusum of an ion overshoots 1 +massTolerance, we stop adding to it, if it reaches our mark we count it and stop adding to it
+
+            List<int> indexes = new List<int>();
+            float[] cusums = new float[scan.Spectrum.Count];
+            int movingPoint = 0;
+            double minimum = 1 - 0.001;
+            double maximum = 1 + 0.001;
+
+            for (int i = 1; i < cusums.Length; i++)
+            {
+                float distance = scan.Spectrum[i].Mz - scan.Spectrum[i - 1].Mz;
+                bool matchedWithLower = false;
+                for (int ii = movingPoint; ii < i; ii++)
+                {
+                    cusums[ii] += distance;
+                    if (cusums[ii] < minimum)
+                        continue;
+                    else if (cusums[ii] > minimum && cusums[ii] < maximum)
+                    {
+                        if (!matchedWithLower) //This is to try and minimise false positives where for example if you have an array: 351.14, 351.15, 352.14 all three get chosen.
+                        {
+                            indexes.Add(i);
+                            indexes.Add(movingPoint);
+                        }
+                        movingPoint += 1;
+                        matchedWithLower = true;
+                        continue;
+                    }
+                    else if (cusums[ii] > maximum)
+                    {
+                        movingPoint += 1;
+                    }
+                }
+            }
+            int distinct = indexes.Distinct().Count();
+            int len = cusums.Length;
+            scan.ProportionChargeStateOne = distinct / (double)len;
+        }
+
+        private static void FindIrtPeptideCandidates(Scan scan, Run run)
         {
             foreach (Library.Peptide peptide in run.AnalysisSettings.IrtLibrary.PeptideList.Values)
             {
@@ -441,7 +137,7 @@ namespace MzmlParser
                     {
                         break;
                     }
-                    var spectrumPoints = spectrum.Where(x => x.Intensity > run.AnalysisSettings.IrtMinIntensity && Math.Abs(x.Mz - t.ProductMz) < run.AnalysisSettings.IrtMassTolerance);
+                    var spectrumPoints = scan.Spectrum.Where(x => x.Intensity > run.AnalysisSettings.IrtMinIntensity && Math.Abs(x.Mz - t.ProductMz) < run.AnalysisSettings.IrtMassTolerance);
                     if (spectrumPoints.Any())
                         irtIntensities.Add(spectrumPoints.Max(x => x.Intensity));
                     transitionsLeftToSearch--;
@@ -453,7 +149,7 @@ namespace MzmlParser
                     {
                         PeptideSequence = peptide.Sequence,
                         Intensities = irtIntensities,
-                        RetentionTime = scan.Scan.ScanStartTime,
+                        RetentionTime = scan.ScanStartTime,
                         PrecursorTargetMz = peptide.AssociatedTransitions.First().PrecursorMz,
                         ProductTargetMzs = peptide.AssociatedTransitions.Select(x => x.ProductMz).ToList()
                     });
@@ -461,13 +157,16 @@ namespace MzmlParser
             }
         }
 
-        private static void AddBasePeakSpectra(Run run)
+        private void AddBasePeakSpectra(Run run)
         {
+            ICouldRunCodeInParallel runner = Threading
+                ? (ICouldRunCodeInParallel)new ThreadPoolScheduler()
+                : new SingleThreadedScheduler();
+
             foreach (Scan scan in run.Ms2Scans)
-            {
-                cde.AddCount();
-                ThreadPool.QueueUserWorkItem(state => FindBasePeaks(run, scan));
-            }
+                runner.Submit(state => FindBasePeaks(run, scan));
+
+            runner.WaitForAll();
         }
 
         private static void FindBasePeaks(Run run, Scan scan)
@@ -478,66 +177,6 @@ namespace MzmlParser
                 if (temp.Any())
                     bp.Spectrum.Add(scan.Spectrum.Where(x => Math.Abs(x.Mz - bp.Mz) <= run.AnalysisSettings.MassTolerance).OrderByDescending(x => x.Intensity).First());
             }
-            cde.Signal();
-        }
-
-        private static float[] ExtractFloatArray(string Base64Array, bool IsZlibCompressed, int bits)
-        {
-            float[] floats = new float[0];
-            byte[] bytes = Convert.FromBase64String(Base64Array);
-
-            if (IsZlibCompressed)
-                bytes = ZlibStream.UncompressBuffer(bytes);
-
-            if (bits == 32)
-                floats = GetFloats(bytes);
-            else if (bits == 64)
-                floats = GetFloatsFromDoubles(bytes);
-            else
-                throw new ArgumentOutOfRangeException("bits", "Numbers must be 32 or 64 bits");
-            return floats;
-        }
-
-        private static float[] GetFloats(byte[] bytes)
-        {
-            float[] floats = new float[bytes.Length / 4];
-            for (int i = 0; i < floats.Length; i++)
-                floats[i] = BitConverter.ToSingle(bytes, i * 4);
-            return floats;
-        }
-
-        private static float[] GetFloatsFromDoubles(byte[] bytes)
-        {
-            float[] floats = new float[bytes.Length / 8];
-            for (int i = 0; i < floats.Length; i++)
-                floats[i] = (float)BitConverter.ToDouble(bytes, i * 8);
-            return floats;
-        }
-
-        private static void AddScanToRun(Scan scan, Run run)
-        {
-            scan.IsolationWindowLowerBoundary = scan.IsolationWindowTargetMz - scan.IsolationWindowLowerOffset;
-            scan.IsolationWindowUpperBoundary = scan.IsolationWindowTargetMz + scan.IsolationWindowUpperOffset;
-
-            if (scan.MsLevel == 1)
-                run.Ms1Scans.Add(scan);
-            else if (scan.MsLevel == 2)
-                run.Ms2Scans.Add(scan);
-            else
-            {
-                throw new ArgumentOutOfRangeException("scan.MsLevel", "MS Level must be 1 or 2");
-            }
-        }
-
-        private static float[] FillZeroArray(float[] array)
-        {
-            System.Array.Resize(ref array, 5);
-            return array;
-        }
-
-        private void FindMs2IsolationWindows(Run run)
-        {
-            run.IsolationWindows = run.Ms2Scans.Select(x => (x.IsolationWindowTargetMz - x.IsolationWindowLowerOffset, x.IsolationWindowTargetMz + x.IsolationWindowUpperOffset)).Distinct().ToList();
         }
     }
 }

--- a/MzmlReader/Run.cs
+++ b/MzmlReader/Run.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using LibraryParser;
 
 namespace MzmlParser
 {
-    public class Run
+    public class Run : IGenericRun<Scan>
     {
         public Run()
         {
@@ -18,18 +17,18 @@ namespace MzmlParser
         }
         public double StartTime { get; set; }
         public double LastScanTime { get; set; }
-        public String SourceFileType { get; set; }
-        public String SourceFileName { get; set; }
-        public String SourceFilePath { get; set; }
-        public String SourceFileChecksum { get; set; }
-        public String CompletionTime { get; set; }
-        public List<Scan> Ms1Scans { get; set; }
+        public string SourceFileType { get; set; }
+        public string SourceFileName { get; set; }
+        public string SourceFilePath { get; set; }
+        public string SourceFileChecksum { get; set; }
+        public string CompletionTime { get; set; }
+        public IList<Scan> Ms1Scans { get; set; }
         public ConcurrentBag<Scan> Ms2Scans { get; set; }
         public ConcurrentBag<BasePeak> BasePeaks { get; set; }
         public Chromatograms Chromatograms { get; set; }
-        public List<(double, double)> IsolationWindows { get; set; }
+        public IList<(double, double)> IsolationWindows { get; set; }
         public int MissingScans { get; set; }
-        public String FilePropertiesAccession;
+        public string FilePropertiesAccession { get; set; }
         public ConcurrentBag<IRTPeak> IRTPeaks { get; set; }
         public ConcurrentBag<CandidateHit> IRTHits { get; set; }
         public AnalysisSettings AnalysisSettings { get; set; }
@@ -42,6 +41,7 @@ namespace MzmlParser
         public List<(double, double)> Ms1Bpc { get; set; }
         public List<(double, double)> Ms2Bpc { get; set; }
     }
+
     public class AnalysisSettings
     {
         public double MassTolerance { get; set; }

--- a/MzmlReader/Scan.cs
+++ b/MzmlReader/Scan.cs
@@ -2,7 +2,7 @@
 
 namespace MzmlParser
 {
-    public class Scan
+    public class Scan : IGenericScan
     {
         public int Cycle { get; set; }
         public int? MsLevel { get; set; }
@@ -17,23 +17,7 @@ namespace MzmlParser
         public double IsolationWindowLowerBoundary { get; set; }
         public int RTsegment { get; set; }
         public int Density { get; set; }
-        public List<SpectrumPoint> Spectrum { get; set; }
-        public double proportionChargeStateOne { get; set; }
-    }
-
-    public class ScanAndTempProperties
-    {
-        public ScanAndTempProperties()
-        {
-            Scan = new Scan();
-        }
-
-        public Scan Scan { get; set; }
-        public string Base64IntensityArray { get; set; }
-        public string Base64MzArray { get; set; }
-        public bool IntensityZlibCompressed { get; set; }
-        public bool MzZlibCompressed { get; set; }
-        public int IntensityBitLength { get; set; }
-        public int MzBitLength { get; set; }
+        public IList<SpectrumPoint> Spectrum { get; set; }
+        public double ProportionChargeStateOne { get; set; }
     }
 }

--- a/MzmlReader/SingleThreadedScheduler.cs
+++ b/MzmlReader/SingleThreadedScheduler.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading;
+
+namespace MzmlParser
+{
+    public class SingleThreadedScheduler : ICouldRunCodeInParallel
+    {
+        void ICouldRunCodeInParallel.Submit(WaitCallback callback)
+        {
+            // Run immediately
+            callback(null);
+        }
+
+        void ICouldRunCodeInParallel.WaitForAll()
+        {
+            // Everything's already been run in series, so nothing more to do.
+            return;
+        }
+    }
+}

--- a/MzmlReader/ThreadPoolScheduler.cs
+++ b/MzmlReader/ThreadPoolScheduler.cs
@@ -9,7 +9,7 @@ namespace MzmlParser
         void ICouldRunCodeInParallel.Submit(WaitCallback callback)
         {
             cde.AddCount(1);
-            ThreadPool.QueueUserWorkItem(callback);
+            ThreadPool.QueueUserWorkItem(state => { callback(state); cde.Signal(); });
         }
 
         void ICouldRunCodeInParallel.WaitForAll()

--- a/MzmlReader/ThreadPoolScheduler.cs
+++ b/MzmlReader/ThreadPoolScheduler.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading;
+
+namespace MzmlParser
+{
+    public class ThreadPoolScheduler : ICouldRunCodeInParallel
+    {
+        private readonly CountdownEvent cde = new CountdownEvent(1);
+
+        void ICouldRunCodeInParallel.Submit(WaitCallback callback)
+        {
+            cde.AddCount(1);
+            ThreadPool.QueueUserWorkItem(callback);
+        }
+
+        void ICouldRunCodeInParallel.WaitForAll()
+        {
+            cde.Wait();
+        }
+    }
+}

--- a/SwaMe/SwathGrouper.cs
+++ b/SwaMe/SwathGrouper.cs
@@ -75,7 +75,7 @@ namespace SwaMe
                     mzTargetRange.Add(scan.IsolationWindowUpperOffset + scan.IsolationWindowLowerOffset);
                     TICthisSwath = TICthisSwath + scan.TotalIonCurrent;
                     swDensity.Add(scan.Density);
-                    TotalSwathProportionPredictedSingleCharge.Add(scan.proportionChargeStateOne); //The chargestate one's we pick up is where there is a match for M+1. Therefore we need to double it to add the M.
+                    TotalSwathProportionPredictedSingleCharge.Add(scan.ProportionChargeStateOne); //The chargestate one's we pick up is where there is a match for M+1. Therefore we need to double it to add the M.
                     track++;
                 }
                 mzTargetRange.Sort();

--- a/Yamato.sln
+++ b/Yamato.sln
@@ -19,7 +19,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CWT", "CWT\CWT.csproj", "{9
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CrawdadSharp", "CrawdadSharp\CrawdadSharp\CrawdadSharp.csproj", "{BAFB0E3D-8370-46FD-9CD5-804A4F7DC316}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryParser.Test", "LibraryParser.Test\LibraryParser.Test.csproj", "{92BEEDE4-3CA2-4D7A-993C-42144AC4A944}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibraryParser.Test", "LibraryParser.Test\LibraryParser.Test.csproj", "{92BEEDE4-3CA2-4D7A-993C-42144AC4A944}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
These changes separate out a fast mzML reader that could be used for any purpose (exposed as GenericMzmlReader) from the retained MzmlReader that does iRT peptide location and other tasks as it goes along.  Use of extension points in GenericMzmlParser should mean that performance is essentially unaffected.