### PR TITLE
Output path fixed

### DIFF
--- a/SwaMe/FileMaker.cs
+++ b/SwaMe/FileMaker.cs
@@ -231,8 +231,8 @@ namespace SwaMe
         }
         public void CheckOutputDirectory(string inputFileInclPath) 
         {
-            string filePath = "";
-            if (inputFileInclPath.Contains(".mzML"))
+            string filePath;
+            if (inputFileInclPath.Contains(".mzML", StringComparison.InvariantCultureIgnoreCase))
             {
                 filePath =  Path.GetDirectoryName(inputFileInclPath);
             }

--- a/SwaMe/FileMaker.cs
+++ b/SwaMe/FileMaker.cs
@@ -234,12 +234,7 @@ namespace SwaMe
             string filePath = "";
             if (inputFileInclPath.Contains(".mzML"))
             {
-                string[] strings = inputFileInclPath.Split("\\");
-                filePath = strings[0];
-                for (int i = 1; i < strings.Count() - 1; i++)
-                {
-                    filePath = filePath +"\\"+ strings[i];
-                }
+                filePath =  Path.GetDirectoryName(inputFileInclPath);
             }
             else { filePath = inputFileInclPath; }
 


### PR DESCRIPTION
CHeckOutputDirectory function failed due to the variable file path being incorrectly named as it refers to the file path including the file name. Within this function, the path is now separated from the file name.