### PR TITLE
Rerouting currentdirectory to inputfile directory before combining files

### DIFF
--- a/SwaMe/MetricGenerator.cs
+++ b/SwaMe/MetricGenerator.cs
@@ -74,6 +74,7 @@ namespace SwaMe
                 string[] swathFilename = { "AllMetricsBySwath_", date, ".tsv" };
                 string[] rtFilename = { "AllRTDividedMetrics_", date, ".tsv" };
                 string[] undividedFilename = { "AllUndividedMetrics_", date, ".tsv" };
+                fileMaker.CheckOutputDirectory(inputFilePath);
                 fileMaker.CombineMultipleFilesIntoSingleFile(date + "_MetricsBySwath_*",string.Join("",swathFilename) );
                 fileMaker.CombineMultipleFilesIntoSingleFile(date + "_RTDividedMetrics_*", string.Join("", rtFilename));
                 fileMaker.CombineMultipleFilesIntoSingleFile(date + "_undividedMetrics_*", string.Join("",undividedFilename));


### PR DESCRIPTION
Otherwise in the first combination the current directory is the location of the last file and only that file included in the combined file.