### PR TITLE
Revise log levels to reflect a user's perception of severity.

### DIFF
--- a/LibraryParser/SVParser.cs
+++ b/LibraryParser/SVParser.cs
@@ -59,7 +59,7 @@ namespace LibraryParser
             }
             else
             {
-                logger.Info("Seperated value file provided for iRT peptides, however the separater could not be established. Please rerun and ensure the file is separated with either a comma, semi-colon or tab.");
+                logger.Fatal("Separated value file provided for iRT peptides, however the separator could not be established. Please rerun and ensure the file is separated with either a comma, semi-colon or tab.");
                 Environment.Exit(0);
             }
 
@@ -86,8 +86,7 @@ namespace LibraryParser
             }
             if (sequenceIndex == 100 || pepMzIndex == 100 || transMzIndex == 100 || intensityIndex == 100)
             {
-                logger.Info("iRT peptides file was provided, but the correct headings could not be found and column could not be distinguished. Please rename your headings as illustrated in the template file.");
-                logger.Info("Exiting program");
+                logger.Fatal("iRT peptides file was provided, but the correct headings could not be found and column could not be distinguished. Please rename your headings as illustrated in the template file.");
                 Environment.Exit(0);
             }
 
@@ -149,7 +148,7 @@ namespace LibraryParser
             string keystring = transition.Id + "-" + transition.PrecursorMz;
             if (library.TransitionList.Contains(keystring))
             {
-                logger.Info("Two of the same peptide - transition combinations were detected. The second entry was not added as a valid transition.Please check your file for duplication.");
+                logger.Warn("Two of the same peptide - transition combinations were detected. The second entry was not added as a valid transition. Please check your file for duplication.");
             }
             else
             {
@@ -190,7 +189,7 @@ namespace LibraryParser
             }
             else
             {
-                logger.Info("Seperated value file provided for iRT peptides, however the separater could not be established. Please rerun and ensure the file is separated with either a comma, semi-colon or tab.");
+                logger.Fatal("Separated value file provided for iRT peptides, however the separator could not be established. Please rerun and ensure the file is separated with either a comma, semi-colon or tab.");
                 Environment.Exit(0);
             }
 
@@ -203,8 +202,7 @@ namespace LibraryParser
             }
             if (transMzIndex == 100)
             {
-                logger.Info("iRT peptides file was provided, but the correct headings could not be found and column could not be distinguished. Please rename your headings as illustrated in the template file.");
-                logger.Info("Exiting program");
+                logger.Fatal("iRT peptides file was provided, but the correct headings could not be found and column could not be distinguished. Please rename your headings as illustrated in the template file.");
                 Environment.Exit(0);
             }
 

--- a/SwaMe.Console/Program.cs
+++ b/SwaMe.Console/Program.cs
@@ -87,18 +87,16 @@ namespace Yamato.Console
 
                 if (analysisSettings.CacheSpectraToDisk)
                 {
-                    Logger.Info("Deleting temp files...");
+                    Logger.Trace("Deleting temp files...");
                     mzmlParser.DeleteTempFiles(run);
                 }
-                Logger.Info("Done!");
+                Logger.Trace("Done!");
 
             });
             }
             catch (Exception ex)
             {
-                Logger.Error("An unexpected error occured:");
-                Logger.Error(ex.Message);
-                Logger.Error(ex.StackTrace);
+                Logger.Fatal(ex, "An unexpected error occured");
                 LogManager.Shutdown();
                 Environment.Exit(1);
             }

--- a/SwaMe.Desktop/Form1.cs
+++ b/SwaMe.Desktop/Form1.cs
@@ -201,16 +201,15 @@ namespace SwaMe.Desktop
 
             if (analysisSettings.CacheSpectraToDisk)
             {
-                logger.Info("Deleting temp files...");
+                logger.Trace("Deleting temp files...");
                 mzmlParser.DeleteTempFiles(run);
             }
-            logger.Info("Done!");
+            logger.Trace("Done!");
             LogManager.Shutdown();
         }
 
         private static void SetVerboseLogging()
         {
-            //logger.Info("Verbose output selected: enabled logging for all levels");
             foreach (var rule in LogManager.Configuration.LoggingRules)
             {
                 rule.EnableLoggingForLevels(LogLevel.Trace, LogLevel.Debug);

--- a/SwaMe.Prognosticator/ChromatogramGenerator.cs
+++ b/SwaMe.Prognosticator/ChromatogramGenerator.cs
@@ -45,7 +45,7 @@ namespace Prognosticator
                 return run.Chromatograms.Ms1Tic.Select((x, i) => new ValueTuple<double, double, double>(x.Item1, x.Item2, run.Chromatograms.Ms2Tic[i].Item2)).ToList();
             else
             {
-                Logger.Warn("Unable to produce combine chromatogram as MS1 and MS2 chromatograms have different nummbers of elements ({0} vs {1})", run.Ms1Scans.Count, run.Ms2Scans.Count);
+                Logger.Warn("Unable to produce combined chromatogram as MS1 and MS2 chromatograms have different nummbers of elements ({0} vs {1})", run.Ms1Scans.Count, run.Ms2Scans.Count);
                 return new List<(double, double, double)>();
             }
         }


### PR DESCRIPTION
Use logger.Fatal when the log message is the last thing that happens before an Environment.Exit().
Designed such that no output should be produced when logging Fatal/Error/Warn (#142).
Couple of minor spelling errors fixed in the process.