### PR TITLE
Add a production Nlog.config and update Nlog version

### DIFF
--- a/LibraryParser/LibraryParser.csproj
+++ b/LibraryParser/LibraryParser.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.6.3" />
+    <PackageReference Include="NLog" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/MzmlParser/MzmlParser.csproj
+++ b/MzmlParser/MzmlParser.csproj
@@ -9,7 +9,7 @@
   
     <PackageReference Include="DotNetZip" Version="1.13.3" />
    
-    <PackageReference Include="NLog" Version="4.6.3" />
+    <PackageReference Include="NLog" Version="4.7.0" />
    
     <PackageReference Include="protobuf-net" Version="2.4.4" />
   </ItemGroup>

--- a/SwaMe.Console/NLog.config.production
+++ b/SwaMe.Console/NLog.config.production
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
+      autoReload="true"
+      throwExceptions="true"
+      internalLogFile="${tempdir}/Yamato_nlog-internal.log">
+  <targets>
+    <target xsi:type="Console" name="stderr" error="true"/>
+  </targets>
+  <rules>
+    <logger name="*" minlevel="Warn" enabled="true" writeTo="stderr"  />
+  </rules>
+</nlog>

--- a/SwaMe.Console/SwaMe.Console.csproj
+++ b/SwaMe.Console/SwaMe.Console.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
+    <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
-    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,6 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="NLog.config.production">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/SwaMe.Desktop/SwaMe.Desktop.csproj
+++ b/SwaMe.Desktop/SwaMe.Desktop.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.6.8" />
+    <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Windows.Forms" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The production config is a suggested one that writes to stderr, not stdout (#141); and outputs nothing below WARN logging level (#142, second part of fix).

This patch also updates NLog to a version that should, in theory, respect a NLog config named as *executable-name*.nlog in the same directory as the executable.  I have been unable to persuade this to work under CentOS 7 on the Manchester CSF3 compute cluster.  There was previously a mix of NLog levels in different projects, so this consolidation is probably helpful regardless.