### PR TITLE
Use better ontology references

### DIFF
--- a/MzqcGenerator/JsonClasses.cs
+++ b/MzqcGenerator/JsonClasses.cs
@@ -52,13 +52,14 @@ namespace MzqcGenerator
             public string version { get; set; }
             public string uri { get; set; }
             public object analysisSettings { get; set; }
-
         }
+
         public class MetaData
         {
             public List<InputFiles> inputFiles { get; set; }
             public List<AnalysisSoftware> analysisSoftware { get; set; }
         }
+
         public class Unit
         {
             public string cvRef { get; set; }
@@ -72,6 +73,7 @@ namespace MzqcGenerator
                 this.name = name;
             }
         }
+
         public class QualityParameters
         {
             public QualityParameters() { }
@@ -84,12 +86,14 @@ namespace MzqcGenerator
                 this.unit = unit;
                 this.value = value;
             }
+
             public string cvRef { get; set; }
             public string accession { get; set; }
             public string name { get; set; }
             public Unit unit { get; set; }
             public dynamic value { get; set; }
         }
+
         public class RunQuality
         {
             public MetaData metadata { get; set; }
@@ -109,7 +113,6 @@ namespace MzqcGenerator
             public NUV MS { get; set; }
             public NUV UO { get; set; }
         }
-
 
         public class MzQC
         {

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -114,9 +114,8 @@ namespace MzqcGenerator
             analysisSoftwarelist.Add(analysisSoftware);
             JsonClasses.MetaData metadata = new JsonClasses.MetaData() { inputFiles = inputFiles, analysisSoftware = analysisSoftwarelist };
             JsonClasses.RunQuality runQualitySingle = new JsonClasses.RunQuality() { metadata = metadata, qualityParameters = qualityParameters.ToArray() };
-            List<JsonClasses.RunQuality> runQuality = new List<JsonClasses.RunQuality>();
-            runQuality.Add(runQualitySingle);
-            JsonClasses.NUV qualityControl = new JsonClasses.NUV() { name = "Proteomics Standards Initiative Quality Control Ontology", uri = "https://raw.githubusercontent.com/HUPO-PSI/mzqc/master/cv/v0_0_11/qc-cv.obo", version = "0.1.0" };
+            List<JsonClasses.RunQuality> runQuality = new List<JsonClasses.RunQuality> { runQualitySingle };
+            JsonClasses.NUV qualityControl = new JsonClasses.NUV() { name = "Proteomics Standards Initiative Quality Control Ontology", uri = "https://github.com/HUPO-PSI/mzQC/raw/master/cv/qc-cv.obo", version = "0.1.0" };
             JsonClasses.NUV massSpectrometry = new JsonClasses.NUV() { name = "Proteomics Standards Initiative Mass Spectrometry Ontology", uri = "https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo", version = "4.1.7" };
             JsonClasses.NUV UnitOntology = new JsonClasses.NUV() { name = "Unit Ontology", uri = "https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo", version = "09:04:2014 13:37" };
             JsonClasses.CV cV = new JsonClasses.CV() { QC = qualityControl, MS = massSpectrometry, UO = UnitOntology };

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -10,10 +10,7 @@ namespace MzqcGenerator
     public class MzqcWriter
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-        public List<JsonClasses.QualityParameters> QualityParameterLookup
-        {
-            get; set;
-        }
+        private IDictionary<string, JsonClasses.QualityParameters> QualityParametersByAccession { get; } = new Dictionary<string, JsonClasses.QualityParameters>();
 
         public List<JsonClasses.Unit> Units { get; }
 
@@ -26,54 +23,57 @@ namespace MzqcGenerator
             JsonClasses.Unit Intensity = new JsonClasses.Unit("MS", "MS:1000042", "Peak Intensity");
             Units = new List<JsonClasses.Unit>() { Count, Second, Mz, Ratio, Intensity };
 
-            QualityParameterLookup = new List<JsonClasses.QualityParameters>();
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:4000053", "Quameter metric: RT-Duration", Second, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:02", "SwaMe metric: swathSizeDifference", Mz, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:4000060", "Quameter metric: MS2-Count", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:04", "SwaMe metric: NumOfSwaths", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:05", "SwaMe metric: Target mz", Mz, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:06", "SwaMe metric: TotalMS2IonCount", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:07", "SwaMe metric: MS2Density50", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:08", "SwaMe metric: MS2DensityIQR", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:4000059", "Quameter metric: MS1-Count", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:09", "SwaMe metric: scansPerSwathGroup", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:10", "SwaMe metric: AvgMzRange", Mz, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:11", "SwaMe metric: SwathProportionOfTotalTIC", Ratio, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:12", "SwaMe metric: swDensity50", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:13", "SwaMe metric: swDensityIQR", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:14", "SwaMe metric: Peakwidths", Second, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:15", "SwaMe metric: PeakCapacity", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:24", "SwaMe metric: TailingFactor", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:XXXXXXXX", "SwaMe metric: MS2PeakPrecision", Mz, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:16", "SwaMe metric: MS1PeakPrecision", Mz, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:17", "SwaMe metric: DeltaTICAverage", Intensity, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:18", "SwaMe metric: DeltaTICIQR", Intensity, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:19", "SwaMe metric: AvgScanTime", Second, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:20", "SwaMe metric: MS2Density", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:21", "SwaMe metric: MS1Density", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:22", "SwaMe metric: MS2TICTotal", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:23", "SwaMe metric: MS1TICTotal", Count, null));
-           
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:99", "Prognosticator Metric: MS1TICQuartiles", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:98", "Prognosticator Metric: MS2TICQuartiles", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:97", "Prognosticator Metric: MS1TIC", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:96", "Prognosticator Metric: MS2TIC", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:95", "Prognosticator Metric: MS1BPC", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:94", "Prognosticator Metric: MS2BPC", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:93", "Prognosticator Metric: CombinedTIC", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:92", "Prognosticator Metric: MS1:MS2 ratio", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:91", "Prognosticator Metric: MS1 weighted median skew", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:90", "Prognosticator Metric: MS2 weighted median skew", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:89", "Prognosticator Metric: MeanIrtMassError", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:88", "Prognosticator Metric: MaxIrtMassError", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:87", "Prognosticator Metric: IrtPeptideFoundProportion", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:86", "Prognosticator Metric: IrtPeptides", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:85", "Prognosticator Metric: IrtPeptidesFound", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:84", "Prognosticator Metric: IrtSpread", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:83", "Prognosticator Metric: MS1TICQuartilesByRT", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:82", "Prognosticator Metric: MS2TICQuartilesByRT", Count, null));
-            QualityParameterLookup.Add(new JsonClasses.QualityParameters("QC", "QC:81", "Prognosticator Metric: IrtOrderedness", Count, null));
+            List<JsonClasses.QualityParameters> qualityParameters = new List<JsonClasses.QualityParameters>
+            {
+                new JsonClasses.QualityParameters("QC", "QC:4000053", "Quameter metric: RT-Duration", Second, null),
+                new JsonClasses.QualityParameters("QC", "QC:02", "SwaMe metric: swathSizeDifference", Mz, null),
+                new JsonClasses.QualityParameters("QC", "QC:4000060", "Quameter metric: MS2-Count", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:04", "SwaMe metric: NumOfSwaths", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:05", "SwaMe metric: Target mz", Mz, null),
+                new JsonClasses.QualityParameters("QC", "QC:06", "SwaMe metric: TotalMS2IonCount", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:07", "SwaMe metric: MS2Density50", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:08", "SwaMe metric: MS2DensityIQR", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:4000059", "Quameter metric: MS1-Count", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:09", "SwaMe metric: scansPerSwathGroup", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:10", "SwaMe metric: AvgMzRange", Mz, null),
+                new JsonClasses.QualityParameters("QC", "QC:11", "SwaMe metric: SwathProportionOfTotalTIC", Ratio, null),
+                new JsonClasses.QualityParameters("QC", "QC:12", "SwaMe metric: swDensity50", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:13", "SwaMe metric: swDensityIQR", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:14", "SwaMe metric: Peakwidths", Second, null),
+                new JsonClasses.QualityParameters("QC", "QC:15", "SwaMe metric: PeakCapacity", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:24", "SwaMe metric: TailingFactor", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:XXXXXXXX", "SwaMe metric: MS2PeakPrecision", Mz, null),
+                new JsonClasses.QualityParameters("QC", "QC:16", "SwaMe metric: MS1PeakPrecision", Mz, null),
+                new JsonClasses.QualityParameters("QC", "QC:17", "SwaMe metric: DeltaTICAverage", Intensity, null),
+                new JsonClasses.QualityParameters("QC", "QC:18", "SwaMe metric: DeltaTICIQR", Intensity, null),
+                new JsonClasses.QualityParameters("QC", "QC:19", "SwaMe metric: AvgScanTime", Second, null),
+                new JsonClasses.QualityParameters("QC", "QC:20", "SwaMe metric: MS2Density", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:21", "SwaMe metric: MS1Density", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:22", "SwaMe metric: MS2TICTotal", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:23", "SwaMe metric: MS1TICTotal", Count, null),
 
+                new JsonClasses.QualityParameters("QC", "QC:99", "Prognosticator Metric: MS1TICQuartiles", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:98", "Prognosticator Metric: MS2TICQuartiles", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:97", "Prognosticator Metric: MS1TIC", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:96", "Prognosticator Metric: MS2TIC", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:95", "Prognosticator Metric: MS1BPC", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:94", "Prognosticator Metric: MS2BPC", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:93", "Prognosticator Metric: CombinedTIC", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:92", "Prognosticator Metric: MS1:MS2 ratio", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:91", "Prognosticator Metric: MS1 weighted median skew", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:90", "Prognosticator Metric: MS2 weighted median skew", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:89", "Prognosticator Metric: MeanIrtMassError", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:88", "Prognosticator Metric: MaxIrtMassError", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:87", "Prognosticator Metric: IrtPeptideFoundProportion", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:86", "Prognosticator Metric: IrtPeptides", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:85", "Prognosticator Metric: IrtPeptidesFound", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:84", "Prognosticator Metric: IrtSpread", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:83", "Prognosticator Metric: MS1TICQuartilesByRT", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:82", "Prognosticator Metric: MS2TICQuartilesByRT", Count, null),
+                new JsonClasses.QualityParameters("QC", "QC:81", "Prognosticator Metric: IrtOrderedness", Count, null)
+            };
+            foreach (var qp in qualityParameters)
+                QualityParametersByAccession.Add(qp.accession, qp);
         }
 
         public void BuildMzqcAndWrite(string outputFileName, Run run, Dictionary<string, dynamic> qcParams, string inputFileInclPath, object analysisSettings)
@@ -81,8 +81,7 @@ namespace MzqcGenerator
             List<JsonClasses.QualityParameters> qualityParameters = new List<JsonClasses.QualityParameters>();
             foreach (var metric in qcParams)
             {
-                var matchingMetric = QualityParameterLookup.SingleOrDefault(x => x.accession == metric.Key);
-                if (matchingMetric != null)
+                if (QualityParametersByAccession.TryGetValue(metric.Key, out var matchingMetric))
                 {
                     matchingMetric.value = metric.Value;
                     qualityParameters.Add(matchingMetric);

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -117,7 +117,7 @@ namespace MzqcGenerator
             List<JsonClasses.RunQuality> runQuality = new List<JsonClasses.RunQuality> { runQualitySingle };
             JsonClasses.NUV qualityControl = new JsonClasses.NUV() { name = "Proteomics Standards Initiative Quality Control Ontology", uri = "https://github.com/HUPO-PSI/mzQC/raw/master/cv/qc-cv.obo", version = "0.1.0" };
             JsonClasses.NUV massSpectrometry = new JsonClasses.NUV() { name = "Proteomics Standards Initiative Mass Spectrometry Ontology", uri = "https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo", version = "4.1.7" };
-            JsonClasses.NUV UnitOntology = new JsonClasses.NUV() { name = "Unit Ontology", uri = "https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo", version = "09:04:2014 13:37" };
+            JsonClasses.NUV UnitOntology = new JsonClasses.NUV() { name = "Unit Ontology", uri = "http://ontologies.berkeleybop.org/uo.obo", version = "releases/2020-03-10" };
             JsonClasses.CV cV = new JsonClasses.CV() { QC = qualityControl, MS = massSpectrometry, UO = UnitOntology };
             JsonClasses.MzQC metrics = new JsonClasses.MzQC() { runQuality = runQuality, cv = cV };
 

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -81,6 +81,7 @@ namespace MzqcGenerator
             List<JsonClasses.QualityParameters> qualityParameters = new List<JsonClasses.QualityParameters>();
             foreach (var metric in qcParams)
             {
+                // Note that this code smashes a value into the given QualityParameters; this will fail if the same one is used more than once, or the initialisation of those parameters is made static.
                 if (QualityParametersByAccession.TryGetValue(metric.Key, out var matchingMetric))
                 {
                     matchingMetric.value = metric.Value;

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -1,4 +1,4 @@
-﻿using MzmlParser;
+using MzmlParser;
 using Newtonsoft.Json;
 using NLog;
 using System.Collections.Generic;
@@ -79,10 +79,8 @@ namespace MzqcGenerator
 
         }
 
-
         public void BuildMzqcAndWrite(string outputFileName, Run run, Dictionary<string, dynamic> qcParams, string inputFileInclPath, object analysisSettings)
         {
-            
             List<JsonClasses.QualityParameters> qualityParameters = new List<JsonClasses.QualityParameters>();
             foreach (var metric in qcParams)
             {
@@ -97,8 +95,7 @@ namespace MzqcGenerator
             }
             //Now for the other stuff
             JsonClasses.FileFormat fileFormat = new JsonClasses.FileFormat() { };
-            List<JsonClasses.FileProperties> fileProperties = new List<JsonClasses.FileProperties>() { };
-
+            List<JsonClasses.FileProperties> fileProperties = new List<JsonClasses.FileProperties>();
 
             JsonClasses.FileProperties fileProperty = new JsonClasses.FileProperties("MS", run.FilePropertiesAccession, "SHA-1", run.SourceFileChecksums.First());
             JsonClasses.FileProperties completionTime = new JsonClasses.FileProperties("MS", "MS:1000747", "completion time", run.CompletionTime);
@@ -130,8 +127,6 @@ namespace MzqcGenerator
 
             //Then save:
             WriteMzqc(outputFileName, metrics);
-
-
         }
 
         public void WriteMzqc(string path, JsonClasses.MzQC metrics)
@@ -148,5 +143,4 @@ namespace MzqcGenerator
             }
         }
     }
-
 }

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -19,7 +19,7 @@ namespace MzqcGenerator
             JsonClasses.Unit Count = new JsonClasses.Unit("UO", "UO:0000189", "count");
             JsonClasses.Unit Second = new JsonClasses.Unit("UO", "UO:0000010", "second");
             JsonClasses.Unit Mz = new JsonClasses.Unit("MS", "MS:1000040", "m/z");
-            JsonClasses.Unit Ratio = new JsonClasses.Unit("UO", "UO:0010006", "ratio");//Also doesn't exist, need to re-evaluate...
+            JsonClasses.Unit Ratio = new JsonClasses.Unit("UO", "UO:0010006", "ratio"); // TODO: What's the difference between this and UO:0000190?
             JsonClasses.Unit Intensity = new JsonClasses.Unit("MS", "MS:1000042", "Peak Intensity");
             Units = new List<JsonClasses.Unit>() { Count, Second, Mz, Ratio, Intensity };
 

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -15,10 +15,7 @@ namespace MzqcGenerator
             get; set;
         }
 
-        public List<JsonClasses.Unit> Units
-        {
-            get; set;
-        }
+        public List<JsonClasses.Unit> Units { get; }
 
         public MzqcWriter()
         {


### PR DESCRIPTION
A number of small commits to MzqcWriter:
* Standardise whitespace (cosmetic)
* Prevent an external agent from setting MzQcWriter's units
* More efficient QualityParameters lookup
* Warn that current MzqcWriter has non-obvious requirements on QualityParameters
* Move to more idiomatic C#
* Mark the Ratio unit selected as rather odd
* Use a more standard URL for UnitOntology OBO
* Use a somewhat less awful URL for mzQC OBO
* (Verified that the URL for psi-MS is the one recommended within the file, which I find extraordinary)