### PR TITLE
Enable pipes on stdin and stdout

### DIFF
--- a/MzmlParser/MzmlReader.cs
+++ b/MzmlParser/MzmlReader.cs
@@ -43,7 +43,7 @@ namespace MzmlParser
         private static bool TicNotFound = false;
         private static bool AnyEmptyBinaryArray = false;
 
-
+        /// <param name="path">The path to the input file to be opened, or null to read from stdin</param>
         public Run LoadMzml(string path, AnalysisSettings analysisSettings)
         {
             if (MaxThreads != 0)
@@ -107,10 +107,10 @@ namespace MzmlParser
             return run;
         }
 
+        /// <param name="path">The path to the input file to be opened, or null to read from stdin</param>
         private void ReadMzml(string path, Run run, bool irt)
         {
-
-            using (XmlReader reader = "-".Equals(path) ? XmlReader.Create(Console.In): XmlReader.Create(path))
+            using (XmlReader reader = null == path ? XmlReader.Create(Console.In): XmlReader.Create(path))
             {
                 Xli = (IXmlLineInfo)reader;
                 while (reader.Read())

--- a/MzmlParser/MzmlReader.cs
+++ b/MzmlParser/MzmlReader.cs
@@ -110,7 +110,7 @@ namespace MzmlParser
         private void ReadMzml(string path, Run run, bool irt)
         {
 
-            using (XmlReader reader = XmlReader.Create(path))
+            using (XmlReader reader = "-".Equals(path) ? XmlReader.Create(Console.In): XmlReader.Create(path))
             {
                 Xli = (IXmlLineInfo)reader;
                 while (reader.Read())

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -77,6 +77,7 @@ namespace MzqcGenerator
                 QualityParametersByAccession.Add(qp.accession, qp);
         }
 
+        /// <param name="outputFileName">The path to the output file to be opened, or null to send to stdout</param>
         public void BuildMzqcAndWrite(string outputFileName, Run run, Dictionary<string, dynamic> qcParams, string inputFileInclPath, object analysisSettings)
         {
             List<JsonClasses.QualityParameters> qualityParameters = new List<JsonClasses.QualityParameters>();
@@ -126,9 +127,10 @@ namespace MzqcGenerator
             WriteMzqc(outputFileName, metrics);
         }
 
+        /// <param name="path">The path to the output file to be opened, or null to send to stdout</param>
         public void WriteMzqc(string path, JsonClasses.MzQC metrics)
         {
-            using (TextWriter file = "-".Equals(path, StringComparison.Ordinal) ? Console.Out : File.CreateText(path))
+            using (TextWriter file = null == path ? Console.Out : File.CreateText(path))
             {
                 file.Write("{ \"mzQC\":");
                 JsonSerializer serializer = new JsonSerializer()

--- a/MzqcGenerator/MzqcWriter.cs
+++ b/MzqcGenerator/MzqcWriter.cs
@@ -1,6 +1,7 @@
 ﻿using MzmlParser;
 using Newtonsoft.Json;
 using NLog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -136,7 +137,7 @@ namespace MzqcGenerator
 
         public void WriteMzqc(string path, JsonClasses.MzQC metrics)
         {
-            using (StreamWriter file = File.CreateText(path))
+            using (TextWriter file = "-".Equals(path, StringComparison.Ordinal) ? Console.Out : File.CreateText(path))
             {
                 file.Write("{ \"mzQC\":");
                 JsonSerializer serializer = new JsonSerializer()

--- a/SwaMe.Console/Program.cs
+++ b/SwaMe.Console/Program.cs
@@ -44,7 +44,9 @@ namespace Yamato.Console
                     MaxThreads = options.MaxThreads
                 };
 
-                CheckFileIsReadableOrComplain(options.InputFile);
+                // stdin is always considered readable; anything else needs a check (#99)
+                if (!"-".Equals(options.InputFile))
+                    CheckFileIsReadableOrComplain(options.InputFile);
 
                 AnalysisSettings analysisSettings = new AnalysisSettings()
                 {
@@ -144,10 +146,10 @@ namespace Yamato.Console
         [Option("dir", Required = false, HelpText = "Load from directory: if true, reads the directory path of the input file path and runs on all .mzml files in that directory")]
         public bool? LoadFromDirectory { get; set; }
 
-        [Option('i', "inputfile", Required = true, HelpText = "Input file path.")]
+        [Option('i', "inputfile", Required = true, HelpText = "Input file path, or - to use standard input.")]
         public string InputFile { get; set; }
 
-        [Option('o', "outputfile", Required = true, HelpText = "Output file path.")]
+        [Option('o', "outputfile", Required = true, HelpText = "Output file path, or - to use standard output (NOTE: Use production logging or your log output will also go to stdout).")]
         public string OutputFile { get; set; }
 
         [Option('v', "verbose", Required = false, HelpText = "Enable verbose logging.")]

--- a/SwaMe.Console/Program.cs
+++ b/SwaMe.Console/Program.cs
@@ -19,10 +19,21 @@ namespace Yamato.Console
             {
                 Parser.Default.ParseArguments<Options>(args).WithParsed(options =>
             {
+                // An inputfile of "-" on the command line denotes stdin, for which we use null internally.
+                if ("-".Equals(options.InputFile, StringComparison.Ordinal))
+                    options.InputFile = null;
+                // An outputfile of "-" on the command line denotes stdout, for which we use null internally.
+                if ("-".Equals(options.OutputFile, StringComparison.Ordinal))
+                    options.OutputFile = null;
+
                 if (options.Verbose)
                     SetVerboseLogging();
 
-                Logger.Info("Loading file: {0}", options.InputFile);
+                if (null == options.InputFile)
+                    Logger.Info("Loading file: {0}", options.InputFile);
+                else
+                    Logger.Info("Reading mzML from standard input");
+
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
@@ -44,8 +55,8 @@ namespace Yamato.Console
                     MaxThreads = options.MaxThreads
                 };
 
-                // stdin is always considered readable; anything else needs a check (#99)
-                if (!"-".Equals(options.InputFile))
+                // stdin (denoted by null) is always considered readable; anything else needs a check (#99)
+                if (null != options.InputFile)
                     CheckFileIsReadableOrComplain(options.InputFile);
 
                 AnalysisSettings analysisSettings = new AnalysisSettings()


### PR DESCRIPTION
In theory, this allows - for stdin or stdout on -i and -o options. In reality, even the most recent version of the "getopt-compatible" command line parser we use is not fully compatible; I suggest we merge this patch now and wait for a new release of the command line parser, at which point this should suddenly Just Work.