### PR TITLE
Improve scan queuing and processing with a custom queue that only stalls the XML parser for the minimum possible time

### DIFF
--- a/MzmlParser/MzmlReader.cs
+++ b/MzmlParser/MzmlReader.cs
@@ -32,6 +32,9 @@ namespace MzmlParser
         private readonly IList<IScanConsumer<TScan, TRun>> scanConsumers = new List<IScanConsumer<TScan, TRun>>();
 
         public CancellationToken CancellationToken { get; set; }
+        /// <summary>
+        /// If null, no queuing is taking place (i.e. Threading is false).
+        /// </summary>
         private ThrottlingConcurrentConsumerQueue<ScanAndTempProperties<TScan, TRun>>? queue;
 
         private bool parseBinaryData;

--- a/MzmlParser/MzmlReader.cs
+++ b/MzmlParser/MzmlReader.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace MzmlParser
 {
-    public class MzmlReader<TScan, TRun> : IDisposable
+    public class MzmlReader<TScan, TRun>
         where TScan: IScan
         where TRun: IRun<TScan>
     {
@@ -27,16 +27,16 @@ namespace MzmlParser
 
         public bool Threading { get; set; }
         public int MaxQueueSize { get; set; } = 1000;
-        public int MaxThreads { get; set; } = 0;
+        public int MaxThreads { get; set; } = 4;
 
         private readonly IList<IScanConsumer<TScan, TRun>> scanConsumers = new List<IScanConsumer<TScan, TRun>>();
 
         public CancellationToken CancellationToken { get; set; }
+        private ThrottlingConcurrentConsumerQueue<ScanAndTempProperties<TScan, TRun>>? queue;
 
         private bool parseBinaryData;
 
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
-        private readonly CountdownEvent cde = new CountdownEvent(1);
         private string? SurveyScanReferenceableParamGroupId; //This is the referenceableparamgroupid for the survey scan
 
         public void Register(IScanConsumer<TScan, TRun> scanConsumer)
@@ -47,25 +47,23 @@ namespace MzmlParser
         /// <param name="path">The path to the input file to be opened, or null to read from stdin</param>
         public TRun LoadMzml(string path)
         {
-            if (MaxThreads != 0)
-                ThreadPool.SetMaxThreads(MaxThreads, MaxThreads);
             TRun run = RunFactory.CreateRun();
             run.StartTime = 100;
             run.LastScanTime = 0;
             parseBinaryData = scanConsumers.Any(scanConsumer => scanConsumer.RequiresBinaryData);
 
+            if (Threading)
+                queue = new ThrottlingConcurrentConsumerQueue<ScanAndTempProperties<TScan, TRun>>(ProcessScan, ToLogicalCores(MaxThreads), MaxQueueSize);
             ReadMzml(path, run);
-
-            cde.Signal();
-            while(cde.CurrentCount > 1)
-            {
-                if (CancellationToken.IsCancellationRequested)
-                    throw new OperationCanceledException("Reading MZML was cancelled");
-
-                Thread.Sleep(500);
-            }
-            cde.Wait();
+            if (null != queue)
+                queue.WaitForAllTasksToComplete();
             return run;
+        }
+
+        /// <remarks>TODO: Tweak the default. Peter suspects this isn't a bad approximation for most systems as they'll need a little in reserve for the XML parser and system tasks, and the rest of the processing is utterly CPU-bound rather than I/O-bound.</remarks>
+        private int ToLogicalCores(int maxThreads)
+        {
+            return maxThreads > 0 ? maxThreads : Environment.ProcessorCount;
         }
 
         /// <param name="path">The path to the input file to be opened, or null to read from stdin</param>
@@ -163,7 +161,7 @@ namespace MzmlParser
             double previousTargetMz = 0;
             int currentCycle = 0;
             bool hasAtLeastOneMS1 = false;
-            ScanAndTempProperties<TScan> scanAndTempProperties = new ScanAndTempProperties<TScan>(scan);
+            ScanAndTempProperties<TScan, TRun> scanAndTempProperties = new ScanAndTempProperties<TScan, TRun>(scan, run);
             while (reader.Read() && !cvParamsRead)
             {
                 if (reader.IsStartElement())
@@ -229,31 +227,22 @@ namespace MzmlParser
 
                     previousTargetMz = scan.IsolationWindowTargetMz;
 
-                    if (parseBinaryData)
-                    {
-                        if (Threading)
-                        {
-                            cde.AddCount();
-                            while (cde.CurrentCount > MaxQueueSize)
-                                Thread.Sleep(1000);
-
-                            ThreadPool.QueueUserWorkItem(state => ParseBase64Data(scanAndTempProperties, run));
-                        }
-                        else
-                        {
-                            ParseBase64Data(scanAndTempProperties, run);
-                        }
-                    }
-                    else
-                    {
-                        AddScanToRun(scanAndTempProperties.Scan, run);
-                    }
+                    ProcessScanThreadedOrNot(scanAndTempProperties);
                     cvParamsRead = true;
                 }
             }
         }
 
-        private static void GetBinaryData(XmlReader reader, ScanAndTempProperties<TScan> scan)
+        private void ProcessScanThreadedOrNot(ScanAndTempProperties<TScan, TRun> scanAndTempProperties)
+        {
+            AddScanToRun(scanAndTempProperties.Scan, scanAndTempProperties.Run);
+            if (null == queue)
+                ProcessScan(scanAndTempProperties);
+            else
+                queue.Enqueue(scanAndTempProperties);
+        }
+
+        private static void GetBinaryData(XmlReader reader, ScanAndTempProperties<TScan, TRun> scan)
         {
             string base64 = string.Empty;
             Bitness bitness = Bitness.NotSet;
@@ -310,16 +299,12 @@ namespace MzmlParser
             }
         }
 
-        private void ParseBase64Data(ScanAndTempProperties<TScan> scanAndTempProperties, TRun run)
+        private void ProcessScan(ScanAndTempProperties<TScan, TRun> scanAndTempProperties)
         {
             float[]? intensities = parseBinaryData ? scanAndTempProperties.Intensities?.ExtractFloatArray() : null;
             float[]? mzs = parseBinaryData ? scanAndTempProperties.Mzs?.ExtractFloatArray() : null;
             foreach (var scanConsumer in scanConsumers)
-                scanConsumer.Notify(scanAndTempProperties.Scan, mzs, intensities, run);
-            AddScanToRun(scanAndTempProperties.Scan, run);
-
-            if (Threading)
-                cde.Signal();
+                scanConsumer.Notify(scanAndTempProperties.Scan, mzs, intensities, scanAndTempProperties.Run);
         }
 
         private void AddScanToRun(TScan scan, TRun run)
@@ -342,29 +327,5 @@ namespace MzmlParser
             else
                 throw new ArgumentOutOfRangeException("scan.MsLevel", "MS Level must be 1 or 2");
         }
-
-        #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    cde.Dispose();
-                }
-
-                disposedValue = true;
-            }
-        }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-        }
-        #endregion
     }
 }

--- a/MzmlParser/ScanAndTempProperties.cs
+++ b/MzmlParser/ScanAndTempProperties.cs
@@ -2,14 +2,17 @@
 
 namespace MzmlParser
 {
-    internal class ScanAndTempProperties<TScan>
+    internal class ScanAndTempProperties<TScan, TRun>
         where TScan: IScan
+        where TRun: IRun<TScan>
     {
-        public ScanAndTempProperties(TScan scan)
+        public ScanAndTempProperties(TScan scan, TRun run)
         {
             Scan = scan;
+            Run = run;
         }
 
+        public TRun Run { get; }
         public TScan Scan { get; }
         public Base64StringAndDecodingHints? Intensities { get; set; }
         public Base64StringAndDecodingHints? Mzs { get; set; }

--- a/MzmlParser/ThrottlingConcurrentConsumerQueue.cs
+++ b/MzmlParser/ThrottlingConcurrentConsumerQueue.cs
@@ -1,0 +1,87 @@
+﻿#nullable enable
+
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MzmlParser
+{
+    /// <summary>
+    /// A Task-based queue that allows a single producer, multiple consumers, and limits the queue depth.
+    /// All queue activity is run on the enqueuing thread, which blocks when maximumQueueDepth is reached.
+    /// </summary>
+    /// <remarks>
+    /// This assumes that the producer tends to be over-eager and hence need throttling, as it will only schedule
+    /// more tasks when the producer enqueues an item or when it is waiting for all tasks to complete.
+    /// It's probably unwise to use this with a bursty producer; it might pause with items in the queue
+    /// but nothing running.
+    /// </remarks>
+    class ThrottlingConcurrentConsumerQueue<T>
+    {
+        private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
+
+        private Action<T> Consumer { get; }
+        private int MaximumConsumers { get; }
+        private int MaximumQueueDepth { get; }
+        private readonly IList<Task> tasks = new List<Task>();
+        private readonly Queue<T> items = new Queue<T>();
+
+        public ThrottlingConcurrentConsumerQueue(Action<T> consumer, int maximumConsumers, int maximumQueueDepth)
+        {
+            Consumer = consumer;
+            MaximumConsumers = Math.Max(maximumConsumers, 1);
+            MaximumQueueDepth = Math.Max(maximumQueueDepth, 1);
+        }
+
+        public void Enqueue(T item)
+        {
+            // Ensure Tasks is as full as possible, maximising the chances of not having to wait for a queue slot.
+            PumpTasks(false);
+            if (items.Count > MaximumQueueDepth)
+                CompleteOneTask().Wait();
+            items.Enqueue(item);
+            // We may have just allowed a consumer to start - check!
+            PumpTasks(false);
+        }
+
+        public void WaitForAllTasksToComplete()
+        {
+            while (tasks.Count > 0 || items.Count > 0)
+                PumpTasks(true);
+        }
+
+        private async Task CompleteOneTask()
+        {
+            try
+            {
+                Task completedTask = await Task.WhenAny(tasks);
+                tasks.Remove(completedTask);
+                await completedTask;
+            }
+            catch (Exception ex)
+            {
+                LOGGER.Warn(ex);
+            }
+        }
+
+        private void PumpTasks(bool waitForAtLeastOneTaskToComplete)
+        {
+            if (waitForAtLeastOneTaskToComplete)
+                CompleteOneTask().Wait();
+            while (tasks.Any(task => task.IsCompleted))
+                CompleteOneTask().Wait();
+            FillTasks();
+        }
+
+        private void FillTasks()
+        {
+            while (items.Count > 0 && tasks.Count < MaximumConsumers)
+            {
+                T item = items.Dequeue();
+                tasks.Add(Task.Run(() => Consumer(item)));
+            }
+        }
+    }
+}

--- a/SwaMe.Console/Program.cs
+++ b/SwaMe.Console/Program.cs
@@ -197,7 +197,7 @@ namespace Yamato.Console
         public int MinimumIntensity { get; set; } = 100;
 
         [Option("maxQueueSize", Required = false, HelpText = "The maximum number of threads to queue. When the number is met, the parser will pause")]
-        public int MaxQueueSize { get; set; } = 1000;
+        public int MaxQueueSize { get; set; } = 100;
 
         [Option("maxThreads", Required = false, HelpText = "The maximum number of worker threads. Set as zero for default system max.")]
         public int MaxThreads { get; set; } = 0;

--- a/SwaMe.Console/Properties/launchSettings.json
+++ b/SwaMe.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Console": {
       "commandName": "Project",
-      "commandLineArgs": "-i d:\\wiffs\\collinsb_I180316_005_SW-A.mzML -r  c:\\wiffs\\hroest_DIA_iRT.TraML -o d:\\wiffs\\outputfile.mzqc --minimumIntensity 0"
+      "commandLineArgs": "-i C:\\Sandbox\\github\\Yamato\\MzmlParser.Test\\mzmls\\test.mzML -r  c:\\Temp\\hroest_DIA_iRT.TraML -o C:\\Temp\\outputfile.mzqc --minimumIntensity 0"
     }
   }
 }

--- a/SwaMe.Pipeline/Pipeliner.cs
+++ b/SwaMe.Pipeline/Pipeliner.cs
@@ -32,16 +32,14 @@ namespace SwaMe.Pipeline
         {
             ScanAndRunFactory factory = new ScanAndRunFactory(analysisSettings);
             Run<Scan> run;
-            using (MzmlReader<Scan, Run<Scan>> parser = new MzmlReader<Scan, Run<Scan>>(factory, factory)
+            MzmlReader<Scan, Run<Scan>> parser = new MzmlReader<Scan, Run<Scan>>(factory, factory)
             {
                 Threading = Threading,
                 MaxThreads = MaxThreads,
                 MaxQueueSize = MaxQueueSize
-            })
-            {
-                parser.Register(this);
-                run = parser.LoadMzml(path);
-            }
+            };
+            parser.Register(this);
+            run = parser.LoadMzml(path);
 
             run.MissingScans = 0;
 


### PR DESCRIPTION
Only applies to MzmlReader at present; the other concurrent parts of the code still use the old CountdownTimer approach.  This is deliberate; I'd like to get a little experience with MzmlReader in a real environment before choosing what approach to use.

I've done some minimal tuning, notably on the thread count.  I suspect the queue depth could be quite a lot shorter without any issues - wouldn't surprise me if a small multiple of the thread count (perhaps 1-2) is appropriate.