### PR TITLE
Prevent some simple race conditions when calculating BasePeaks

### DIFF
--- a/SwaMe.Pipeline/DoubleSpectrumPoint.cs
+++ b/SwaMe.Pipeline/DoubleSpectrumPoint.cs
@@ -1,0 +1,16 @@
+﻿#nullable enable
+
+namespace SwaMe.Pipeline
+{
+    public class DoubleSpectrumPoint : GenericSpectrumPoint<double>
+    {
+        public DoubleSpectrumPoint()
+        {
+        }
+
+        public DoubleSpectrumPoint(double intensity, double mz, double retentionTime)
+            : base(intensity, mz, retentionTime)
+        {
+        }
+    }
+}

--- a/SwaMe.Pipeline/GenericSpectrumPoint.cs
+++ b/SwaMe.Pipeline/GenericSpectrumPoint.cs
@@ -1,0 +1,52 @@
+﻿#nullable enable
+
+using ProtoBuf;
+
+namespace SwaMe.Pipeline
+{
+    /// <summary>
+    /// A point in the 2-dimensional LC-MS space of retention time and m/z, recording intensity at this coordinate.
+    /// </summary>
+    /// <remarks>
+    /// Arguably, this should be a struct, for ease of memory management and pointer dereferencing within the VM.
+    /// It's arguable because the class reduces copying overhead of arrays, so the optimisation depends on the exact use case.
+    /// 
+    /// Paul Brack 2019/04/16
+    /// 
+    /// I've done some performance testing trying to load a SWATH map into memory. RAM use (and execution time) halves with
+    /// this as a struct - this is our current bottleneck and on a 64GB RAM machine I can now load a 249K scan SWATH file 
+    /// directly into memory now this has been changed. 
+    /// </remarks>
+    [ProtoContract]
+    public class GenericSpectrumPoint<T> where T: struct
+    {
+        public GenericSpectrumPoint()
+        {
+        }
+
+        public GenericSpectrumPoint(T intensity, T mz, T retentionTime)
+        {
+            Intensity = intensity;
+            Mz = mz;
+            RetentionTime = retentionTime;
+        }
+
+        /// <remarks>Depending on the use of this class, this may be raw retention time or iRT. Within MzmlParser, it's raw and in minutes.</remarks>
+        [ProtoMember(1)]
+        public T RetentionTime { get; set; }
+
+        /// <summary>
+        /// Mass over charge, in Daltons.
+        /// </summary>
+        [ProtoMember(2)]
+        public T Mz { get; set; }
+
+        [ProtoMember(3)]
+        public T Intensity { get; set; }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(RetentionTime={RetentionTime}, Mz={Mz}, Intensity={Intensity})";
+        }
+    }
+}

--- a/SwaMe.Pipeline/Pipeliner.cs
+++ b/SwaMe.Pipeline/Pipeliner.cs
@@ -245,43 +245,65 @@ namespace SwaMe.Pipeline
             float basepeakIntensity;
             if (intensities.Count() > 0)
             {
+                // TODO: This approach requires two scans across intensities plus converting intensities to a List; is there a simpler approach involving a single scan in a for-next loop?
                 basepeakIntensity = intensities.Max();
                 int maxIndex = intensities.ToList().IndexOf(basepeakIntensity);
                 double mz = mzs[maxIndex];
 
-                if (run.BasePeaks.Count(x => Math.Abs(x.Mz - mz) < run.AnalysisSettings.MassTolerance) < 1)//If a basepeak with this mz doesn't exist yet add it
-                {
-                    BasePeak bp = new BasePeak(mz, scan.ScanStartTime, basepeakIntensity);
-                    run.BasePeaks.Add(bp);
-                }
-                else //we do have a match, now lets figure out if they fall within the rtTolerance
-                {
-                    //find out which basepeak
-                    foreach (BasePeak thisbp in run.BasePeaks.Where(x => Math.Abs(x.Mz - mz) < run.AnalysisSettings.MassTolerance))
-                    {
-                        bool found = false;
-                        for (int rt = 0; rt < thisbp.BpkRTs.Count(); rt++)
-                        {
-                            if (Math.Abs(thisbp.BpkRTs[rt] - scan.ScanStartTime) < run.AnalysisSettings.RtTolerance)//this is part of a previous basepeak, or at least considered to be 
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (!found)//This is considered to be a new instance
-                        {
-                            thisbp.BpkRTs.Add(scan.ScanStartTime);
-                            thisbp.Intensities.Add(basepeakIntensity);
-                        }
-                    }
-                }
+                AtomicallyRecordBasePeakAndRT(new DoubleSpectrumPoint(basepeakIntensity, mz, scan.ScanStartTime), run);
             }
-            else { basepeakIntensity = 0; }
+            else
+            {
+                basepeakIntensity = 0;
+            }
             //Extract info for Basepeak chromatograms
 
             bool irt = run.AnalysisSettings.IrtLibrary != null;
             if (irt)
                 FindIrtPeptideCandidates(scan, run, spectrum);
+        }
+
+        /// <summary>
+        /// Atomically test-and-set the BasePeak(s) and BpkRT(s) that we're going to use for this point.
+        /// This may involve creating a new BasePeak, or a new BpkRt inside one or more existing BasePeaks.
+        /// </summary>
+        private static void AtomicallyRecordBasePeakAndRT(DoubleSpectrumPoint point, Run<Scan> run)
+        {
+            BasePeak[] candidates;
+            lock (run.BasePeaks)
+            {
+                candidates = run.BasePeaks.Where(x => Math.Abs(x.Mz - point.Mz) < run.AnalysisSettings.MassTolerance).ToArray();
+                if (0 == candidates.Length)
+                {
+                    // No basepeak with this mz exists yet, so add it
+                    run.BasePeaks.Add(new BasePeak(point.Mz, point.RetentionTime, point.Intensity));
+                    return;
+                }
+            }
+
+            // If we get here, we have one or more matches within our mass tolerance.  Ensure there's a BpkRt in each match that's within rtTolerance of this scan.
+            // Because we're doing this in each BasePeak match, rather than picking a "best" candidate, we don't need to do this inside the lock on all BasePeaks;
+            // we just need to ensure that no other thread can be checking BpkRTs for the same candidate at the same time.
+            foreach (BasePeak candidate in candidates)
+            {
+                bool found = false;
+                lock (candidate)
+                {
+                    foreach (double rt in candidate.BpkRTs)
+                    {
+                        if (Math.Abs(rt - point.RetentionTime) < run.AnalysisSettings.RtTolerance) // This is considered to be part of a previous basepeak
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) // No matching BpkRt in this BasePeak, so add one.
+                    {
+                        candidate.BpkRTs.Add(point.RetentionTime);
+                        candidate.Intensities.Add(point.Intensity);
+                    }
+                }
+            }
         }
 
         #region IDisposable Support

--- a/SwaMe.Pipeline/Run.cs
+++ b/SwaMe.Pipeline/Run.cs
@@ -18,7 +18,11 @@ namespace SwaMe.Pipeline
         public string? CompletionTime { get; set; }
         public List<TScan> Ms1Scans { get; } = new List<TScan>();
         public List<TScan> Ms2Scans { get; } = new List<TScan>();
-        public ConcurrentBag<BasePeak> BasePeaks { get; } = new ConcurrentBag<BasePeak>();
+        /// <remarks>
+        /// BEWARE: BasePeaks has concurrent read-calculate-write access.  If writing, please lock on the BasePeaks object.
+        /// It is not a concurrent datatype because read-calculate-write accesses are not amenable to being defended in that way.
+        /// </remarks>
+        public List<BasePeak> BasePeaks { get; } = new List<BasePeak>();
         public Chromatograms Chromatograms { get; } = new Chromatograms();
         public List<(double, double)>? IsolationWindows { get; set; }
         public int MissingScans { get; set; }

--- a/SwaMe.Test/SwaMe.Test/RTGrouperTests.cs
+++ b/SwaMe.Test/SwaMe.Test/RTGrouperTests.cs
@@ -154,7 +154,7 @@ namespace SwaMe.Test
         [TestMethod]
         public void RtsegmentsAllocatedToFirstBasePeakCorrect()
         {
-            Assert.AreEqual(Ms2andms1Run.BasePeaks.ElementAt(0).RTsegments.ElementAt(0), 1);
+            Assert.AreEqual(Ms2andms1Run.BasePeaks.ElementAt(0).RTsegments.ElementAt(0), 2);
         }
         /// <remarks>
         /// RTSegs is correctly allocated to basepeaks - second.
@@ -162,7 +162,7 @@ namespace SwaMe.Test
         [TestMethod]
         public void rtsegmentsAllocatedToSecondBasePeakCorrect()
         {
-            Assert.AreEqual(Ms2andms1Run.BasePeaks.ElementAt(1).RTsegments.ElementAt(0), 2);
+            Assert.AreEqual(Ms2andms1Run.BasePeaks.ElementAt(1).RTsegments.ElementAt(0), 1);
         }
         /// <remarks>
         /// RTSegs is correctly allocated to scans - first.


### PR DESCRIPTION
This merely prevents errors due to reading an intermediate state (the A in ACID transactions).  Note that a more complex race condition is still present: there is non-determinism in whether a given BasePeak or BpkRt is created based on the state of the run at that time.  This patch does not (and cannot) address that.